### PR TITLE
[Deploy] CI-CD 에서 GitHub 의 OIDC 를 사용하도록 한다.

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -13,7 +13,7 @@ esac
 
 # [#12] feat: message
 # [#12] fix(auth): message
-pattern='^\[#([0-9]+)\][[:space:]]+(feat|fix|docs|style|refactor|test|chore|perf/infra)(\([^)]+\))?:[[:space:]]+.+'
+pattern='^\[#([0-9]+)\][[:space:]]+(feat|fix|docs|style|refactor|test|chore|perf|infra)(\([^)]+\))?:[[:space:]]+.+'
 
 if ! printf "%s" "$first_line" | grep -Eq "$pattern"; then
   echo "❌ 커밋 메시지 형식이 올바르지 않습니다."

--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - release/frontend
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -48,14 +52,16 @@ jobs:
           echo "Checking for HTML files:"
           find out/ -name "*.html" -type f || echo "No HTML files found"
 
-      # ✅ next.config.js에 output:'export'가 설정돼 있으면 out/ 생성됨
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ap-northeast-2
+
       - name: Upload to S3
         run: |
-          aws s3 sync out/ s3://${{ secrets.S3_BUCKET }}/${{ secrets.S3_PATH }} --delete --exclude "*.map"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ap-northeast-2
+          aws s3 sync out/ s3://${{ secrets.S3_BUCKET }}/${{ secrets.S3_PATH }} \
+            --delete --exclude "*.map"
 
       - name: Invalidate CloudFront cache
         continue-on-error: true
@@ -66,7 +72,3 @@ jobs:
             --query 'Invalidation.Id' \
             --output text)
           echo "CloudFront invalidation created: $INVALIDATION_ID"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ap-northeast-2


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
- CI-CD 에서 GitHub 의 OIDC 를 사용하도록 한다.


### Issue
- closes #10 


### Why
- GitHub 에 AWS Key 를 저장하지 않고, iam 만 연결하여 보안 키 노출을 방지한다.

### What
- [x] GitHub Action 에서 iam 계정 연동
- [x] Iam 에서 GitHub OIDC Role 생성
- [x] TrustPolicy 에 조건 추가


### Test
- Secret 변수를 사용하지 않고 Front 배포가 정상적으로 이루어지는지 확인
