### PR TITLE
채팅방 목록 조회 API 구현

### DIFF
--- a/live-chat-server/src/main/java/org/giglab/live/application/dto/GetRoomResponse.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/dto/GetRoomResponse.java
@@ -1,0 +1,24 @@
+package org.giglab.live.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.giglab.live.domain.model.Room;
+
+/**
+ * @author : JAKE
+ * @date : 26. 1. 11.
+ */
+@Getter
+@AllArgsConstructor
+public class GetRoomResponse {
+
+  private String roomId;
+  private String title;
+
+  public static GetRoomResponse from(Room room) {
+    return new GetRoomResponse(
+      room.getRoomId(),
+      room.getTitle()
+    );
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/application/service/RoomService.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/service/RoomService.java
@@ -20,6 +20,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class RoomService {
 
+  private static final int MAX_SIZE = 20;
+
   private final RoomRepository roomRepository;
 
   public CreateRoomResponse createRoom(CreateRoomRequest request) {
@@ -34,7 +36,8 @@ public class RoomService {
   }
 
   public List<GetRoomResponse> getRooms(int size) {
-    List<String> roomIds = roomRepository.findLatestRoomIds(size);
+    int validSize = Math.min(MAX_SIZE, size);
+    List<String> roomIds = roomRepository.findLatestRoomIds(validSize);
     if (roomIds.isEmpty()) {
       return Collections.emptyList();
     }

--- a/live-chat-server/src/main/java/org/giglab/live/application/service/RoomService.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/service/RoomService.java
@@ -3,9 +3,14 @@ package org.giglab.live.application.service;
 import lombok.RequiredArgsConstructor;
 import org.giglab.live.application.dto.CreateRoomRequest;
 import org.giglab.live.application.dto.CreateRoomResponse;
+import org.giglab.live.application.dto.GetRoomResponse;
 import org.giglab.live.domain.model.Room;
 import org.giglab.live.domain.repository.RoomRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * @author : JAKE
@@ -26,5 +31,14 @@ public class RoomService {
       saved.getCreatedAt(),
       saved.getUpdatedAt()
     );
+  }
+
+  public List<GetRoomResponse> getRooms(int size) {
+    List<String> roomIds = roomRepository.findLatestRoomIds(size);
+    return roomIds.stream()
+      .map(roomRepository::findById)
+      .flatMap(Optional::stream)
+      .map(GetRoomResponse::from)
+      .collect(Collectors.toList());
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/application/service/RoomService.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/service/RoomService.java
@@ -8,8 +8,8 @@ import org.giglab.live.domain.model.Room;
 import org.giglab.live.domain.repository.RoomRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -35,9 +35,11 @@ public class RoomService {
 
   public List<GetRoomResponse> getRooms(int size) {
     List<String> roomIds = roomRepository.findLatestRoomIds(size);
-    return roomIds.stream()
-      .map(roomRepository::findById)
-      .flatMap(Optional::stream)
+    if (roomIds.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    return roomRepository.getRoomsByIds(roomIds)
       .map(GetRoomResponse::from)
       .collect(Collectors.toList());
   }

--- a/live-chat-server/src/main/java/org/giglab/live/domain/repository/RoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/domain/repository/RoomRepository.java
@@ -4,6 +4,7 @@ import org.giglab.live.domain.model.Room;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * @author : JAKE
@@ -14,6 +15,8 @@ public interface RoomRepository {
   Room save(Room room);
 
   List<String> findLatestRoomIds(int limit);
+
+  Stream<Room> getRoomsByIds(List<String> roomIds);
 
   Optional<Room> findById(String roomId);
 }

--- a/live-chat-server/src/main/java/org/giglab/live/domain/repository/RoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/domain/repository/RoomRepository.java
@@ -2,10 +2,18 @@ package org.giglab.live.domain.repository;
 
 import org.giglab.live.domain.model.Room;
 
+import java.util.List;
+import java.util.Optional;
+
 /**
  * @author : JAKE
  * @date : 26. 1. 11.
  */
 public interface RoomRepository {
+
   Room save(Room room);
+
+  List<String> findLatestRoomIds(int limit);
+
+  Optional<Room> findById(String roomId);
 }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
@@ -79,7 +79,7 @@ public class RedisRoomRepository implements RoomRepository {
       ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
       Set<Object> roomIds = zSetOps.reverseRange(ROOM_INDEX_KEY, 0, limit - 1);
 
-      if (roomIds.isEmpty()) {
+      if (roomIds == null || roomIds.isEmpty()) {
         return Collections.emptyList();
       }
 

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
@@ -11,6 +11,10 @@ import org.springframework.stereotype.Repository;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author : JAKE
@@ -46,6 +50,41 @@ public class RedisRoomRepository implements RoomRepository {
       log.error("Failed to save room to Redis: roomId={}, key={}, error={}",
         room.getRoomId(), roomKey, e.getMessage(), e);
       throw new RedisOperationException("SAVE", roomKey, e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public List<String> findLatestRoomIds(int limit) {
+
+    try {
+      ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+      Set<Object> roomIds = zSetOps.reverseRange(ROOM_INDEX_KEY, 0, limit -1);
+
+      if (roomIds.isEmpty()) {
+        return Collections.emptyList();
+      }
+
+      return roomIds.stream()
+        .map(Object::toString)
+        .toList();
+
+    } catch (Exception e) {
+      log.error("Failed to get latest rooms: limit={}, error={}", limit, e.getMessage(), e);
+      throw new RedisOperationException("GET_LATEST_ROOMS", ROOM_INDEX_KEY, e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public Optional<Room> findById(String roomId) {
+    String roomKey = String.format("%s:%s", ROOM_KEY_PREFIX, roomId);
+
+    try {
+      Room room = (Room) redisTemplate.opsForValue().get(roomKey);
+      return Optional.ofNullable(room);
+    } catch (Exception e) {
+      log.error("Failed to find room by id: roomId={}, key={}, error={}",
+        roomId, roomKey, e.getMessage(), e);
+      throw new RedisOperationException("FIND_BY_ID", roomId, e.getMessage(), e);
     }
   }
 

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -109,6 +110,17 @@ public class RedisRoomRepository implements RoomRepository {
         return Stream.empty();
       }
 
+      List<String> expiredRoomIds = new ArrayList<>();
+      for (int i=0; i<roomIds.size(); i++) {
+        if (rooms.get(i) == null) {
+          expiredRoomIds.add(roomIds.get(i));
+        }
+      }
+
+      if (!expiredRoomIds.isEmpty()) {
+        removeIndexAsync(expiredRoomIds);
+      }
+
       return rooms.stream()
         .filter(Objects::nonNull)
         .map(obj -> (Room) obj);
@@ -156,5 +168,16 @@ public class RedisRoomRepository implements RoomRepository {
         roomId, roomKey, e.getMessage(), e);
       throw new RedisOperationException("FIND_BY_ID", roomId, e.getMessage(), e);
     }
+  }
+
+  private void removeIndexAsync(List<String> expiredRoomIds) {
+    CompletableFuture.runAsync(() -> {
+      try {
+        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        zSetOps.remove(ROOM_INDEX_KEY, expiredRoomIds.toArray());
+      } catch (Exception e) {
+        log.error("Failed to remove expired room IDs: error={}", e.getMessage(), e);
+      }
+    });
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
@@ -4,7 +4,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.giglab.live.domain.model.Room;
 import org.giglab.live.domain.repository.RoomRepository;
 import org.giglab.live.infrastructure.redis.exception.RedisOperationException;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
 
@@ -38,11 +41,27 @@ public class RedisRoomRepository implements RoomRepository {
     String roomKey = String.format("%s:%s", ROOM_KEY_PREFIX, room.getRoomId());
 
     try {
-      // 1. 채팅방 정보 저장
-      redisTemplate.opsForValue().set(roomKey, room, ROOM_TTL);
 
-      // 2. ZSET 인덱스에 채팅방 추가
-      addToRoomIndex(room);
+      LocalDateTime createdAt = room.getCreatedAt();
+      long score = createdAt.atZone(ZoneId.systemDefault())
+        .toInstant()
+          .getEpochSecond();
+
+      List<Object> results = redisTemplate.execute(new SessionCallback<List<Object>>() {
+        @Override
+        @SuppressWarnings("unchecked")
+        public <K, V> List<Object> execute(RedisOperations<K, V> operations) throws DataAccessException {
+          operations.multi();
+
+          operations.opsForValue().set((K) roomKey, (V) room, ROOM_TTL);
+          operations.opsForZSet().add((K) ROOM_INDEX_KEY, (V) room.getRoomId(), score);
+          return operations.exec();
+        }
+      });
+
+      if (results == null || results.isEmpty()) {
+        throw new RedisOperationException("SAVE", roomKey, "Transaction failed", null);
+      }
 
       return room;
     } catch (Exception e) {
@@ -85,6 +104,9 @@ public class RedisRoomRepository implements RoomRepository {
         .toList();
 
       List<Object> rooms = redisTemplate.opsForValue().multiGet(keys);
+      if (rooms == null || rooms.isEmpty()) {
+        return Stream.empty();
+      }
 
       return rooms.stream()
         .filter(Objects::nonNull)

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
@@ -156,22 +156,4 @@ public class RedisRoomRepository implements RoomRepository {
       throw new RedisOperationException("FIND_BY_ID", roomId, e.getMessage(), e);
     }
   }
-
-  private void addToRoomIndex(Room room) {
-    try {
-      ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
-
-      // 생성 시간을 epoch seconds로 변환하여 score로 사용
-      LocalDateTime createdAt = room.getCreatedAt();
-      long score = createdAt.atZone(ZoneId.systemDefault())
-        .toInstant()
-        .getEpochSecond();
-
-      zSetOps.add(ROOM_INDEX_KEY, room.getRoomId(), score);
-    } catch (Exception e) {
-      log.error("Failed to add room to index: roomId={}, error={}",
-        room.getRoomId(), e.getMessage(), e);
-      throw new RedisOperationException("ADD_TO_INDEX", ROOM_INDEX_KEY, e.getMessage(), e);
-    }
-  }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
@@ -5,9 +5,12 @@ import org.giglab.live.domain.model.Room;
 import org.giglab.live.domain.repository.RoomRepository;
 import org.giglab.live.infrastructure.redis.exception.RedisOperationException;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 /**
  * @author : JAKE
@@ -18,6 +21,7 @@ import java.time.Duration;
 public class RedisRoomRepository implements RoomRepository {
 
   private static final String ROOM_KEY_PREFIX = "LIVE:ROOM";
+  private static final String ROOM_INDEX_KEY = "LIVE:ROOM:INDEX";
   private static final Duration ROOM_TTL = Duration.ofDays(7);
 
   private final RedisTemplate<String, Object> redisTemplate;
@@ -28,14 +32,38 @@ public class RedisRoomRepository implements RoomRepository {
 
   @Override
   public Room save(Room room) {
-    String key = String.format("%s:%s", ROOM_KEY_PREFIX, room.getRoomId());
+    String roomKey = String.format("%s:%s", ROOM_KEY_PREFIX, room.getRoomId());
 
     try {
-      redisTemplate.opsForValue().set(key, room, ROOM_TTL);
+      // 1. 채팅방 정보 저장
+      redisTemplate.opsForValue().set(roomKey, room, ROOM_TTL);
+
+      // 2. ZSET 인덱스에 채팅방 추가
+      addToRoomIndex(room);
+
       return room;
     } catch (Exception e) {
-      log.error("Failed to save room to Redis: roomId={}, key={}, error={}", room.getRoomId(), key, e.getMessage(), e);
-      throw new RedisOperationException("SAVE", key, e.getMessage(), e);
+      log.error("Failed to save room to Redis: roomId={}, key={}, error={}",
+        room.getRoomId(), roomKey, e.getMessage(), e);
+      throw new RedisOperationException("SAVE", roomKey, e.getMessage(), e);
+    }
+  }
+
+  private void addToRoomIndex(Room room) {
+    try {
+      ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+
+      // 생성 시간을 epoch seconds로 변환하여 score로 사용
+      LocalDateTime createdAt = room.getCreatedAt();
+      long score = createdAt.atZone(ZoneId.systemDefault())
+        .toInstant()
+        .getEpochSecond();
+
+      zSetOps.add(ROOM_INDEX_KEY, room.getRoomId(), score);
+    } catch (Exception e) {
+      log.error("Failed to add room to index: roomId={}, error={}",
+        room.getRoomId(), e.getMessage(), e);
+      throw new RedisOperationException("ADD_TO_INDEX", ROOM_INDEX_KEY, e.getMessage(), e);
     }
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
@@ -43,9 +43,10 @@ public class RedisRoomRepository implements RoomRepository {
     try {
 
       LocalDateTime createdAt = room.getCreatedAt();
-      long score = createdAt.atZone(ZoneId.systemDefault())
+      long score = createdAt
+        .atZone(ZoneId.systemDefault())
         .toInstant()
-          .getEpochSecond();
+        .toEpochMilli();
 
       List<Object> results = redisTemplate.execute(new SessionCallback<List<Object>>() {
         @Override

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
@@ -11,10 +11,9 @@ import org.springframework.stereotype.Repository;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author : JAKE
@@ -58,7 +57,7 @@ public class RedisRoomRepository implements RoomRepository {
 
     try {
       ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
-      Set<Object> roomIds = zSetOps.reverseRange(ROOM_INDEX_KEY, 0, limit -1);
+      Set<Object> roomIds = zSetOps.reverseRange(ROOM_INDEX_KEY, 0, limit - 1);
 
       if (roomIds.isEmpty()) {
         return Collections.emptyList();
@@ -71,6 +70,54 @@ public class RedisRoomRepository implements RoomRepository {
     } catch (Exception e) {
       log.error("Failed to get latest rooms: limit={}, error={}", limit, e.getMessage(), e);
       throw new RedisOperationException("GET_LATEST_ROOMS", ROOM_INDEX_KEY, e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public Stream<Room> getRoomsByIds(List<String> roomIds) {
+    if (roomIds.isEmpty()) {
+      return Stream.empty();
+    }
+
+    try {
+      List<String> keys = roomIds.stream()
+        .map(roomId -> String.format("%s:%s", ROOM_KEY_PREFIX, roomId))
+        .toList();
+
+      List<Object> rooms = redisTemplate.opsForValue().multiGet(keys);
+
+      return rooms.stream()
+        .filter(Objects::nonNull)
+        .map(obj -> (Room) obj);
+    } catch (Exception e) {
+      log.error("Failed to get rooms: roomId={}, error={}", roomIds, e.getMessage(), e);
+      throw new RedisOperationException("FIND_BY_IDS", ROOM_KEY_PREFIX, e.getMessage(), e);
+    }
+  }
+
+  @Deprecated
+  public List<Room> getRoomsByIdsAsList(List<String> roomIds) {
+    if (roomIds.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    try {
+      // 1. key 순회
+      List<String> keys = roomIds.stream()
+        .map(roomId -> String.format("%s:%s", ROOM_KEY_PREFIX, roomId))
+        .toList();
+
+      List<Object> rooms = redisTemplate.opsForValue().multiGet(keys);
+
+      // 2. Room 으로 변환
+      // 3. service 에서 다시 GetRoomResponse 로 변환
+      return rooms.stream()
+        .filter(Objects::nonNull)
+        .map(obj -> (Room) obj)
+        .collect(Collectors.toList());
+    } catch (Exception e) {
+      log.error("Failed to get rooms: roomId={}, error={}", roomIds, e.getMessage(), e);
+      throw new RedisOperationException("FIND_BY_IDS", ROOM_KEY_PREFIX, e.getMessage(), e);
     }
   }
 

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/RoomController.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/RoomController.java
@@ -4,11 +4,14 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.giglab.live.application.dto.CreateRoomRequest;
 import org.giglab.live.application.dto.CreateRoomResponse;
+import org.giglab.live.application.dto.GetRoomResponse;
 import org.giglab.live.application.service.RoomService;
 import org.giglab.live.presentation.api.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * @author : JAKE
@@ -20,6 +23,14 @@ import org.springframework.web.bind.annotation.*;
 public class RoomController {
 
   private final RoomService roomService;
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<GetRoomResponse>>> getRooms(
+    @RequestParam(defaultValue = "20") int size
+  ) {
+    List<GetRoomResponse> responses = roomService.getRooms(size);
+    return new ResponseEntity<>(ApiResponse.success(responses), HttpStatus.OK);
+  }
 
   @PostMapping
   public ResponseEntity<ApiResponse<CreateRoomResponse>> createRoom(

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/RoomController.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/RoomController.java
@@ -26,7 +26,7 @@ public class RoomController {
 
   @GetMapping
   public ResponseEntity<ApiResponse<List<GetRoomResponse>>> getRooms(
-    @RequestParam(defaultValue = "20") int size
+    @RequestParam(defaultValue = "10") int size
   ) {
     List<GetRoomResponse> responses = roomService.getRooms(size);
     return new ResponseEntity<>(ApiResponse.success(responses), HttpStatus.OK);

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/RoomController.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/RoomController.java
@@ -1,6 +1,7 @@
 package org.giglab.live.presentation.api.v1.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.giglab.live.application.dto.CreateRoomRequest;
 import org.giglab.live.application.dto.CreateRoomResponse;
@@ -26,7 +27,7 @@ public class RoomController {
 
   @GetMapping
   public ResponseEntity<ApiResponse<List<GetRoomResponse>>> getRooms(
-    @RequestParam(defaultValue = "10") int size
+    @RequestParam(defaultValue = "10") @Min(1) int size
   ) {
     List<GetRoomResponse> responses = roomService.getRooms(size);
     return new ResponseEntity<>(ApiResponse.success(responses), HttpStatus.OK);

--- a/live-chat-server/src/test/http/room.http
+++ b/live-chat-server/src/test/http/room.http
@@ -23,4 +23,4 @@ Content-Type: application/json
 }
 
 ### 채팅방 목록 조회 (최신순)
-GET http://localhost:8080/api/v1/rooms?size=20
+GET http://localhost:8080/api/v1/rooms?size=10

--- a/live-chat-server/src/test/http/room.http
+++ b/live-chat-server/src/test/http/room.http
@@ -21,3 +21,6 @@ Content-Type: application/json
 {
   "title": "이 채팅방은 제목 길이 제한 테스트를 위해 일부러 오십자를 초과하도록 만든 채팅방 제목입니다"
 }
+
+### 채팅방 목록 조회 (최신순)
+GET http://localhost:8080/api/v1/rooms?size=20

--- a/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/RoomControllerTest.java
+++ b/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/RoomControllerTest.java
@@ -2,6 +2,7 @@ package org.giglab.live.presentation.api.v1.controller;
 
 import org.giglab.live.application.dto.CreateRoomRequest;
 import org.giglab.live.application.dto.CreateRoomResponse;
+import org.giglab.live.application.dto.GetRoomResponse;
 import org.giglab.live.application.service.RoomService;
 import org.giglab.live.presentation.api.error.GlobalExceptionHandler;
 import org.junit.jupiter.api.DisplayName;
@@ -15,10 +16,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import tools.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -160,5 +164,29 @@ class RoomControllerTest {
       .andDo(print())
       .andExpect(status().isCreated())
       .andExpect(jsonPath("$.data.title").value("A".repeat(50)));
+  }
+
+  @Test
+  @DisplayName("채팅방 목록 조회 성공 - 최신순 정렬 확인")
+  void getRooms_ReturnsInLatestOrder() throws Exception {
+    // given
+    GetRoomResponse latest = new GetRoomResponse("ROOM_003", "최신 채팅방");
+    GetRoomResponse middle = new GetRoomResponse("ROOM_002", "중간 채팅방");
+    GetRoomResponse oldest = new GetRoomResponse("ROOM_001", "오래된 채팅방");
+
+    List<GetRoomResponse> responses = Arrays.asList(latest, middle, oldest);
+
+    given(roomService.getRooms(3))
+      .willReturn(responses);
+
+    // when & then
+    mockMvc.perform(get("/api/v1/rooms")
+        .param("size", "3"))
+      .andDo(print())
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.data[0].roomId").value("ROOM_003"))  // 최신이 첫 번째
+      .andExpect(jsonPath("$.data[0].title").value("최신 채팅방"))
+      .andExpect(jsonPath("$.data[1].roomId").value("ROOM_002"))
+      .andExpect(jsonPath("$.data[2].roomId").value("ROOM_001"));  // 오래된 것이 마지막
   }
 }


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
- 사용자는 **생성된 채팅방 목록**을 조회할 수 있다.
- Redis에는 Room 단건 조회용 Key-Value(JSON) 구조를 유지하면서,  
  **목록 조회 안정성과 정렬/페이징 확장을 위해 ZSET 인덱스(`rooms:index`)를 추가**한다.
- 목록 조회는 **ZSET에서 roomId 목록을 조회한 뒤**, 각 Room 상세는 `room:{roomId}`에서 조회하여 응답한다.


### Issue
- closes #20 


### Why
- 사용자는 채팅방 목록을 조회할 수 있다.


### What

### 1. Redis 저장 구조 확장 (ZSET 인덱스)
- [x] Room 단건 저장 키 유지  
  - `room:{roomId}` → JSON String
- [x] Room 목록 인덱스 키 추가  
  - `rooms:index` (ZSET)  
  - member: `{roomId}`  
  - score: `createdAtEpochMillis`
- [x] 채팅방 생성 시 인덱스 동기화  
  - `ZADD rooms:index {createdAtEpochMillis} {roomId}`

---

### 2. 채팅방 목록 조회 API 구현
- [x] API 정의  
  - `GET /api/v1/rooms`
- [x] Query Parameter  
  - `size` (optional): 기본 10. 최대 20
- [x] Response DTO 정의  
  - `GetRoomResponse`
    - `rooms: [{ roomId, title }]`

---

### 3. Redis 조회 로직 구현 (안정성 중심)
- [x] 기본 목록 조회 (cursor 없음)  
  - `ZREVRANGE rooms:index 0 size-1`

---

### 4. 테스트 작성
- [x] Controller 테스트  
  - 목록 조회 시 200 OK 반환
- [x] 최신순 정렬 테스트  

---

### How
- redis zset 기반으로 채팅방 정보 저장 시 최신순으로 정렬 및 조회할 수 있도록 함


### Test
- Test Code, http.test
