### PR TITLE
LocalDateTime 에서 Instant 로 타입 변경 및 Redis serializer 문제 해결

### DIFF
--- a/live-chat-server/src/main/java/org/giglab/live/config/JacksonConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/config/JacksonConfig.java
@@ -1,14 +1,9 @@
 package org.giglab.live.config;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import java.io.IOException;
-import java.time.Instant;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -21,20 +16,6 @@ public class JacksonConfig {
   public ObjectMapper objectMapper() {
     ObjectMapper mapper = new ObjectMapper();
     JavaTimeModule javaTimeModule = new JavaTimeModule();
-
-    javaTimeModule.addDeserializer(
-        Instant.class,
-        new JsonDeserializer<>() {
-          @Override
-          public Instant deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-            String text = p.getText();
-            try {
-              return Instant.parse(text);
-            } catch (Exception e) {
-              throw new IOException("Cannot parse Instant: " + text, e);
-            }
-          }
-        });
 
     mapper.registerModule(javaTimeModule);
     // 활성화 시 숫자 timestamp format 으로 저장됨 (1737162824002)

--- a/live-chat-server/src/main/java/org/giglab/live/config/JacksonConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/config/JacksonConfig.java
@@ -1,4 +1,4 @@
-package org.giglab.live.infrastructure.redis.config;
+package org.giglab.live.config;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
@@ -68,8 +68,7 @@ public class RedisRoomRepository implements RoomRepository {
         throw new RedisOperationException("SAVE", roomKey, "Transaction failed", null);
       }
 
-      Object savedObj = redisTemplate.opsForValue().get(roomKey);
-      return convertToRoom(savedObj);
+      return room;
     } catch (Exception e) {
       log.error(
           "Failed to save room to Redis: roomId={}, key={}, error={}",

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
@@ -2,7 +2,6 @@ package org.giglab.live.infrastructure.redis;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -10,6 +9,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.giglab.live.domain.model.Room;
@@ -110,12 +110,11 @@ public class RedisRoomRepository implements RoomRepository {
         return Stream.empty();
       }
 
-      List<String> expiredRoomIds = new ArrayList<>();
-      for (int i = 0; i < roomIds.size(); i++) {
-        if (rooms.get(i) == null) {
-          expiredRoomIds.add(roomIds.get(i));
-        }
-      }
+      List<String> expiredRoomIds =
+          IntStream.range(0, rooms.size())
+              .filter(i -> rooms.get(i) == null)
+              .mapToObj(roomIds::get)
+              .toList();
 
       if (!expiredRoomIds.isEmpty()) {
         removeIndexAsync(expiredRoomIds);

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
@@ -1,5 +1,6 @@
 package org.giglab.live.infrastructure.redis;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
@@ -31,9 +32,12 @@ public class RedisRoomRepository implements RoomRepository {
   private static final Duration ROOM_TTL = Duration.ofDays(7);
 
   private final RedisTemplate<String, Object> redisTemplate;
+  private final ObjectMapper objectMapper;
 
-  public RedisRoomRepository(RedisTemplate<String, Object> redisTemplate) {
+  public RedisRoomRepository(
+      RedisTemplate<String, Object> redisTemplate, ObjectMapper objectMapper) {
     this.redisTemplate = redisTemplate;
+    this.objectMapper = objectMapper;
   }
 
   @Override
@@ -64,7 +68,8 @@ public class RedisRoomRepository implements RoomRepository {
         throw new RedisOperationException("SAVE", roomKey, "Transaction failed", null);
       }
 
-      return room;
+      Object savedObj = redisTemplate.opsForValue().get(roomKey);
+      return convertToRoom(savedObj);
     } catch (Exception e) {
       log.error(
           "Failed to save room to Redis: roomId={}, key={}, error={}",
@@ -120,7 +125,7 @@ public class RedisRoomRepository implements RoomRepository {
         removeIndexAsync(expiredRoomIds);
       }
 
-      return rooms.stream().filter(Objects::nonNull).map(obj -> (Room) obj);
+      return rooms.stream().filter(Objects::nonNull).map(this::convertToRoom);
     } catch (Exception e) {
       log.error("Failed to get rooms: roomId={}, error={}", roomIds, e.getMessage(), e);
       throw new RedisOperationException("FIND_BY_IDS", ROOM_KEY_PREFIX, e.getMessage(), e);
@@ -144,7 +149,7 @@ public class RedisRoomRepository implements RoomRepository {
       // 3. service 에서 다시 GetRoomResponse 로 변환
       return rooms.stream()
           .filter(Objects::nonNull)
-          .map(obj -> (Room) obj)
+          .map(this::convertToRoom)
           .collect(Collectors.toList());
     } catch (Exception e) {
       log.error("Failed to get rooms: roomId={}, error={}", roomIds, e.getMessage(), e);
@@ -168,6 +173,17 @@ public class RedisRoomRepository implements RoomRepository {
           e);
       throw new RedisOperationException("FIND_BY_ID", roomId, e.getMessage(), e);
     }
+  }
+
+  private Room convertToRoom(Object obj) {
+    if (obj == null) {
+      return null;
+    }
+    if (obj instanceof Room) {
+      return (Room) obj;
+    }
+
+    return objectMapper.convertValue(obj, Room.class);
   }
 
   private void removeIndexAsync(List<String> expiredRoomIds) {

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/JacksonConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/JacksonConfig.java
@@ -1,0 +1,47 @@
+package org.giglab.live.infrastructure.redis.config;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.IOException;
+import java.time.Instant;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class JacksonConfig {
+
+  @Bean
+  @Primary
+  public ObjectMapper objectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    JavaTimeModule javaTimeModule = new JavaTimeModule();
+
+    javaTimeModule.addDeserializer(
+        Instant.class,
+        new JsonDeserializer<>() {
+          @Override
+          public Instant deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            String text = p.getText();
+            try {
+              return Instant.parse(text);
+            } catch (Exception e) {
+              throw new IOException("Cannot parse Instant: " + text, e);
+            }
+          }
+        });
+
+    mapper.registerModule(javaTimeModule);
+    // 활성화 시 숫자 timestamp format 으로 저장됨 (1737162824002)
+    mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    // 알 수 없는 필드 무시
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    return mapper;
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/JsonRedisSerializer.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/JsonRedisSerializer.java
@@ -1,0 +1,39 @@
+package org.giglab.live.infrastructure.redis.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.SerializationException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JsonRedisSerializer implements RedisSerializer<Object> {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public byte[] serialize(@Nullable Object value) throws SerializationException {
+    if (value == null) {
+      return new byte[0];
+    }
+    try {
+      return objectMapper.writeValueAsBytes(value);
+    } catch (Exception e) {
+      throw new SerializationException("Could not serialize", e);
+    }
+  }
+
+  @Override
+  public @Nullable Object deserialize(byte @Nullable [] bytes) throws SerializationException {
+    if (bytes == null || bytes.length == 0) {
+      return null;
+    }
+    try {
+      return objectMapper.readValue(bytes, Object.class);
+    } catch (Exception e) {
+      throw new SerializationException("Could not deserialize", e);
+    }
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/RedisConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/RedisConfig.java
@@ -1,16 +1,20 @@
 package org.giglab.live.infrastructure.redis.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Nullable;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.SerializationException;
 
 @Configuration
 public class RedisConfig {
 
   @Bean
-  public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+  public RedisTemplate<String, Object> redisTemplate(
+      RedisConnectionFactory connectionFactory, ObjectMapper objectMapper) {
     RedisTemplate<String, Object> template = new RedisTemplate<>();
     template.setConnectionFactory(connectionFactory);
 
@@ -18,10 +22,35 @@ public class RedisConfig {
     template.setKeySerializer(RedisSerializer.string());
     template.setHashKeySerializer(RedisSerializer.string());
 
-    // value 는 JSON 으로 직렬화
-    template.setValueSerializer(RedisSerializer.json());
-    template.setHashValueSerializer(RedisSerializer.json());
+    RedisSerializer<Object> jsonSerializer =
+        new RedisSerializer<>() {
+          @Override
+          public byte[] serialize(@Nullable Object value) {
+            if (value == null) {
+              return new byte[0];
+            }
+            try {
+              return objectMapper.writeValueAsBytes(value);
+            } catch (Exception e) {
+              throw new SerializationException("Could not serialize", e);
+            }
+          }
 
+          @Override
+          public @Nullable Object deserialize(byte[] bytes) {
+            if (bytes == null || bytes.length == 0) {
+              return null;
+            }
+            try {
+              return objectMapper.readValue(bytes, Object.class);
+            } catch (Exception e) {
+              throw new SerializationException("Could not deserialize", e);
+            }
+          }
+        };
+
+    template.setValueSerializer(jsonSerializer);
+    template.setHashValueSerializer(jsonSerializer);
     template.afterPropertiesSet();
     return template;
   }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/RedisConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/RedisConfig.java
@@ -1,20 +1,17 @@
 package org.giglab.live.infrastructure.redis.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.annotation.Nullable;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.RedisSerializer;
-import org.springframework.data.redis.serializer.SerializationException;
 
 @Configuration
 public class RedisConfig {
 
   @Bean
   public RedisTemplate<String, Object> redisTemplate(
-      RedisConnectionFactory connectionFactory, ObjectMapper objectMapper) {
+      RedisConnectionFactory connectionFactory, JsonRedisSerializer jsonRedisSerializer) {
     RedisTemplate<String, Object> template = new RedisTemplate<>();
     template.setConnectionFactory(connectionFactory);
 
@@ -22,35 +19,9 @@ public class RedisConfig {
     template.setKeySerializer(RedisSerializer.string());
     template.setHashKeySerializer(RedisSerializer.string());
 
-    RedisSerializer<Object> jsonSerializer =
-        new RedisSerializer<>() {
-          @Override
-          public byte[] serialize(@Nullable Object value) {
-            if (value == null) {
-              return new byte[0];
-            }
-            try {
-              return objectMapper.writeValueAsBytes(value);
-            } catch (Exception e) {
-              throw new SerializationException("Could not serialize", e);
-            }
-          }
-
-          @Override
-          public @Nullable Object deserialize(byte[] bytes) {
-            if (bytes == null || bytes.length == 0) {
-              return null;
-            }
-            try {
-              return objectMapper.readValue(bytes, Object.class);
-            } catch (Exception e) {
-              throw new SerializationException("Could not deserialize", e);
-            }
-          }
-        };
-
-    template.setValueSerializer(jsonSerializer);
-    template.setHashValueSerializer(jsonSerializer);
+    // value 는 JSON 으로 직렬화 (custom serializer 사용)
+    template.setValueSerializer(jsonRedisSerializer);
+    template.setHashValueSerializer(jsonRedisSerializer);
     template.afterPropertiesSet();
     return template;
   }


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
- LocalDateTime을 Instant로 변경하여 시간대 독립적인 타입으로 통일
- Redis 직렬화/역직렬화에서 발생하는 마이크로초 파싱 오류 및 LinkedHashMap 캐스팅 문제 해결


### Issue
- closes #22 


### What
- [x] 도메인 모델 및 DTO의 날짜 필드를 `LocalDateTime` → `Instant`로 변경
- [x] `RedisRoomRepository`의 날짜 처리 로직을 `Instant` 기반으로 수정
- [x] `JacksonConfig` 생성 및 `Instant` Deserializer 추가 (마이크로초 형식 처리)
- [x] `JsonRedisSerializer` 클래스 분리 및 Bean 등록
- [x] `RedisRoomRepository`에 `convertToRoom()` 메서드 추가 및 적용


### Test
- API 응답에서 날짜가 ISO-8601 형식으로 일관되게 반환됨
- 모든 테스트 및 Checkstyle 검사 통과
