### PR TITLE
[#38] feat: 프론트엔드 페이지 구성 (방송·상품·채팅·포트폴리오)

### DIFF
--- a/web-client/pages/broadcasts.tsx
+++ b/web-client/pages/broadcasts.tsx
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+type BroadcastStatus = 'scheduled' | 'live' | 'ended';
+
+interface Broadcast {
+  id: string;
+  title: string;
+  productName: string;
+  productId: string;
+  status: BroadcastStatus;
+  startedAt?: string;
+}
+
+interface Product {
+  id: string;
+  name: string;
+  category: string;
+}
+
+const MOCK_PRODUCTS: Product[] = [
+  { id: 'P001', name: '워터프루프 립스틱', category: '뷰티' },
+  { id: 'P002', name: '비타민C 세럼', category: '스킨케어' },
+  { id: 'P003', name: '쿠션 파운데이션', category: '뷰티' },
+];
+
+const MOCK_BROADCASTS: Broadcast[] = [
+  { id: 'B001', title: '봄맞이 뷰티 라이브', productName: '워터프루프 립스틱', productId: 'P001', status: 'live', startedAt: '14:00' },
+  { id: 'B002', title: '스킨케어 집중 케어', productName: '비타민C 세럼', productId: 'P002', status: 'scheduled' },
+  { id: 'B003', title: '파운데이션 비교 테스트', productName: '쿠션 파운데이션', productId: 'P003', status: 'ended', startedAt: '10:00' },
+];
+
+const statusLabel: Record<BroadcastStatus, string> = {
+  scheduled: '예정',
+  live: '라이브 중',
+  ended: '종료',
+};
+
+const statusClass: Record<BroadcastStatus, string> = {
+  scheduled: 'status-scheduled',
+  live: 'status-live',
+  ended: 'status-ended',
+};
+
+export default function Broadcasts() {
+  const router = useRouter();
+  const [broadcasts] = useState<Broadcast[]>(MOCK_BROADCASTS);
+
+  return (
+    <>
+      <Head><title>방송 목록 — Live Platform Lab</title></Head>
+      <style jsx global>{`* { margin: 0; padding: 0; box-sizing: border-box; } body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f172a; color: #e2e8f0; min-height: 100vh; } a { text-decoration: none; color: inherit; }`}</style>
+      <style jsx>{`
+        .container { max-width: 1100px; margin: 0 auto; padding: 40px 24px; }
+        .nav { display: flex; align-items: center; gap: 8px; margin-bottom: 40px; font-size: 14px; color: #64748b; }
+        .nav a:hover { color: #a5b4fc; }
+        .nav-sep { color: #334155; }
+        .header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
+        .title { font-size: 28px; font-weight: 700; color: #f1f5f9; }
+        .header-actions { display: flex; align-items: center; gap: 10px; }
+        .btn-products { padding: 10px 18px; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); color: #94a3b8; border-radius: 8px; font-size: 14px; font-weight: 600; transition: border-color 0.2s, color 0.2s; }
+        .btn-products:hover { border-color: rgba(99,102,241,0.4); color: #a5b4fc; }
+        .btn-add { padding: 10px 22px; background: linear-gradient(135deg, #6366f1, #8b5cf6); color: white; border: none; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; transition: opacity 0.2s, transform 0.2s; }
+        .btn-add:hover { opacity: 0.9; transform: translateY(-1px); }
+        .rag-notice { display: flex; align-items: center; padding: 10px 16px; background: rgba(99,102,241,0.06); border: 1px solid rgba(99,102,241,0.15); border-radius: 10px; font-size: 13px; color: #64748b; margin-bottom: 28px; }
+        .rag-notice-link { margin-left: auto; font-size: 13px; font-weight: 600; color: #6366f1; }
+        .rag-notice-link:hover { color: #a5b4fc; }
+        .list { display: flex; flex-direction: column; gap: 14px; }
+        .card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); border-radius: 14px; padding: 24px; display: flex; align-items: center; justify-content: space-between; gap: 20px; transition: border-color 0.2s; }
+        .card:hover { border-color: rgba(99,102,241,0.3); }
+        .card.live { border-color: rgba(239,68,68,0.4); background: rgba(239,68,68,0.04); }
+        .card-left { flex: 1; min-width: 0; }
+        .card-title { font-size: 18px; font-weight: 700; color: #f1f5f9; margin-bottom: 8px; }
+        .card-meta { display: flex; align-items: center; gap: 10px; font-size: 13px; color: #64748b; }
+        .product-tag { background: rgba(99,102,241,0.12); border: 1px solid rgba(99,102,241,0.2); color: #a5b4fc; padding: 2px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; }
+        .started-at { font-size: 12px; }
+        .card-right { display: flex; align-items: center; gap: 14px; flex-shrink: 0; }
+        .status-badge { font-size: 12px; font-weight: 700; padding: 4px 12px; border-radius: 999px; }
+        .status-live { background: rgba(239,68,68,0.15); color: #fca5a5; border: 1px solid rgba(239,68,68,0.3); }
+        .status-live::before { content: '● '; }
+        .status-scheduled { background: rgba(251,191,36,0.12); color: #fcd34d; border: 1px solid rgba(251,191,36,0.25); }
+        .status-ended { background: rgba(100,116,139,0.12); color: #94a3b8; border: 1px solid rgba(100,116,139,0.2); }
+        .btn-enter { padding: 8px 20px; border-radius: 8px; font-size: 13px; font-weight: 600; cursor: pointer; border: none; transition: opacity 0.2s; }
+        .btn-enter-live { background: #ef4444; color: white; }
+        .btn-enter-live:hover { opacity: 0.85; }
+        .btn-enter-normal { background: rgba(99,102,241,0.15); border: 1px solid rgba(99,102,241,0.3); color: #a5b4fc; }
+        .btn-enter-normal:hover { background: rgba(99,102,241,0.25); }
+      `}</style>
+
+      <div className="container">
+        <nav className="nav">
+          <Link href="/">홈</Link>
+          <span className="nav-sep">/</span>
+          <span>방송 목록</span>
+        </nav>
+
+        <div className="header">
+          <h1 className="title">방송 목록</h1>
+          <div className="header-actions">
+            <Link href="/products" className="btn-products">
+              상품 관리
+            </Link>
+            <button className="btn-add" onClick={() => router.push('/broadcasts/new')}>+ 방송 생성</button>
+          </div>
+        </div>
+        <div className="rag-notice">
+          방송에 연결된 상품 정보는 AI Q&A에 자동으로 활용됩니다.
+          <Link href="/products" className="rag-notice-link">상품 관리 →</Link>
+        </div>
+
+        <div className="list">
+          {broadcasts.map((b) => (
+            <div key={b.id} className={`card ${b.status === 'live' ? 'live' : ''}`}>
+              <div className="card-left">
+                <div className="card-title">{b.title}</div>
+                <div className="card-meta">
+                  <span className="product-tag">📦 {b.productName}</span>
+                  {b.startedAt && <span className="started-at">시작 {b.startedAt}</span>}
+                </div>
+              </div>
+              <div className="card-right">
+                <span className={`status-badge ${statusClass[b.status]}`}>
+                  {statusLabel[b.status]}
+                </span>
+                <button
+                  className={`btn-enter ${b.status === 'live' ? 'btn-enter-live' : 'btn-enter-normal'}`}
+                  onClick={() => router.push(`/broadcasts/${b.id}`)}
+                >
+                  {b.status === 'ended' ? '다시보기' : '입장'}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+    </>
+  );
+}

--- a/web-client/pages/broadcasts/[id].tsx
+++ b/web-client/pages/broadcasts/[id].tsx
@@ -1,0 +1,832 @@
+import React, { useState, useRef, useEffect } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import Script from 'next/script';
+import { useRouter } from 'next/router';
+
+type BroadcastStatus = 'scheduled' | 'live' | 'ended';
+
+interface Broadcast {
+  id: string;
+  title: string;
+  productName: string;
+  productId: string;
+  status: BroadcastStatus;
+  startedAt?: string;
+  viewerCount?: number;
+  description?: string;
+}
+
+interface Message {
+  id: number;
+  nickname: string;
+  text: string;
+  timestamp: Date;
+}
+
+interface QnAItem {
+  id: number;
+  question: string;
+  answer: string;
+  askedBy?: string;
+  timestamp: Date;
+  isLoading?: boolean;
+}
+
+const MOCK_BROADCASTS: Broadcast[] = [
+  {
+    id: 'B001',
+    title: '봄맞이 뷰티 라이브',
+    productName: '워터프루프 립스틱',
+    productId: 'P001',
+    status: 'live',
+    startedAt: '14:00',
+    viewerCount: 1243,
+    description: '봄 시즌 신상 립스틱을 직접 발색해보는 라이브입니다. 다양한 컬러와 지속력을 확인해보세요!',
+  },
+  {
+    id: 'B002',
+    title: '스킨케어 집중 케어',
+    productName: '비타민C 세럼',
+    productId: 'P002',
+    status: 'scheduled',
+    description: '피부 고민을 한 번에 해결해줄 비타민C 세럼 소개 라이브입니다.',
+  },
+  {
+    id: 'B003',
+    title: '파운데이션 비교 테스트',
+    productName: '쿠션 파운데이션',
+    productId: 'P003',
+    status: 'ended',
+    startedAt: '10:00',
+    viewerCount: 3892,
+    description: '인기 쿠션 파운데이션 5종을 직접 비교해보는 방송입니다.',
+  },
+];
+
+const MOCK_PRODUCTS = [
+  { id: 'P001', name: '워터프루프 립스틱', category: '뷰티', price: 25000, embeddingStatus: 'done' },
+  { id: 'P002', name: '비타민C 세럼', category: '스킨케어', price: 48000, embeddingStatus: 'done' },
+  { id: 'P003', name: '쿠션 파운데이션', category: '뷰티', price: 35000, embeddingStatus: 'none' },
+];
+
+// Mock AI 응답
+const MOCK_AI_ANSWERS: Record<string, string> = {
+  default: '해당 상품에 대한 정보를 분석 중입니다. 잠시 후 답변을 제공해드릴게요.',
+  '성분': '이 제품은 피부에 자극이 적은 성분으로 구성되어 있으며, 피부과 테스트를 완료했습니다.',
+  '지속력': '워터프루프 포뮬러로 최대 12시간 지속됩니다. 물이나 땀에도 번짐 없이 유지됩니다.',
+  '발색': '한 번만 발라도 선명한 발색이 가능하며, 레이어링 시 더욱 진하게 연출할 수 있습니다.',
+  '가격': '정상가 28,000원이며, 방송 기간 한정으로 특가 할인이 적용됩니다.',
+  '배송': '오늘 주문 시 내일 오후까지 배송 완료됩니다. 5만원 이상 무료배송입니다.',
+};
+
+const MOCK_LIVE_FAQS: QnAItem[] = [
+  { id: 1, question: '방수 기능이 진짜 있나요?', answer: '', askedBy: '뷰티러버', timestamp: new Date(Date.now() - 8 * 60000) },
+  { id: 2, question: '컬러가 몇 가지나 있어요?', answer: '', askedBy: '핑크사랑', timestamp: new Date(Date.now() - 5 * 60000) },
+  { id: 3, question: '민감한 피부도 사용 가능한가요?', answer: '', askedBy: '피부걱정', timestamp: new Date(Date.now() - 3 * 60000) },
+  { id: 4, question: '맥 립스틱이랑 비교하면 어때요?', answer: '', askedBy: '화장품덕후', timestamp: new Date(Date.now() - 1 * 60000) },
+];
+
+const MOCK_AI_ANALYSIS = {
+  peakViewers: 1892,
+  totalMessages: 4231,
+  avgWatchTime: '18분 32초',
+  sentiment: { positive: 72, neutral: 20, negative: 8 },
+  topKeywords: ['발색', '지속력', '가격', '방수', '향기', '촉촉함'],
+  topQuestions: [
+    '다른 컬러도 있나요?',
+    '민감성 피부도 사용 가능한가요?',
+    '방수 기능이 얼마나 지속되나요?',
+  ],
+  insights: [
+    '시청자의 72%가 발색력에 긍정적인 반응을 보였습니다.',
+    '"방수" 키워드 언급이 전체 메시지의 18%를 차지해 주요 관심 포인트로 확인됐습니다.',
+    '방송 시작 후 8분~12분 구간에서 채팅 참여율이 최고조에 달했습니다.',
+    '가격 관련 질문이 많아 다음 방송 시 가격 혜택을 초반에 강조하는 것을 추천합니다.',
+  ],
+};
+
+const statusLabel: Record<BroadcastStatus, string> = {
+  scheduled: '예정',
+  live: '라이브 중',
+  ended: '종료',
+};
+
+// ─── 예정/라이브 공용: 채팅 + Q&A 탭 패널 ───────────────────────────
+function ChatQnAPanel({
+  status,
+  productName,
+  messages,
+  inputValue,
+  setInputValue,
+  nickname,
+  setNickname,
+  onSend,
+  wsConnected,
+  onToggleWs,
+  areScriptsReady,
+}: {
+  status: BroadcastStatus;
+  productName: string;
+  messages: Message[];
+  inputValue: string;
+  setInputValue: (v: string) => void;
+  nickname: string;
+  setNickname: (v: string) => void;
+  onSend: () => void;
+  wsConnected: boolean;
+  onToggleWs: () => void;
+  areScriptsReady: boolean;
+}) {
+  const isScheduled = status === 'scheduled';
+  const [tab, setTab] = useState<'chat' | 'faq'>('chat');
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const faqBottomRef = useRef<HTMLDivElement>(null);
+  const [liveFaqs] = useState<QnAItem[]>(MOCK_LIVE_FAQS);
+
+  // 예정 탭: AI Q&A 상태
+  const [aiInput, setAiInput] = useState('');
+  const [aiQnaList, setAiQnaList] = useState<QnAItem[]>([
+    {
+      id: 1,
+      question: '이 제품은 어떤 피부 타입에 적합한가요?',
+      answer: '건성, 지성, 복합성 모든 피부 타입에 사용 가능합니다. 특히 수분 밸런스를 유지하는 포뮬러로 구성되어 있습니다.',
+      timestamp: new Date(Date.now() - 30 * 60000),
+    },
+    {
+      id: 2,
+      question: '발색이 자연스러운가요, 선명한가요?',
+      answer: '레이어링 방법에 따라 조절 가능합니다. 한 번 발랐을 때는 데일리로 쓰기 좋은 자연스러운 발색이고, 두 번 이상 발랐을 때는 선명한 컬러가 연출됩니다.',
+      timestamp: new Date(Date.now() - 15 * 60000),
+    },
+  ]);
+
+  useEffect(() => {
+    if (tab === 'chat') messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, tab]);
+
+  useEffect(() => {
+    if (tab === 'faq') faqBottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [aiQnaList, tab]);
+
+  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') onSend();
+  };
+
+  const askAI = () => {
+    const q = aiInput.trim();
+    if (!q) return;
+    setAiInput('');
+    const newItem: QnAItem = { id: Date.now(), question: q, answer: '', timestamp: new Date(), isLoading: true };
+    setAiQnaList((prev) => [...prev, newItem]);
+    const keyword = Object.keys(MOCK_AI_ANSWERS).find((k) => k !== 'default' && q.includes(k));
+    const answer = MOCK_AI_ANSWERS[keyword ?? 'default'];
+    setTimeout(() => {
+      setAiQnaList((prev) => prev.map((item) => item.id === newItem.id ? { ...item, answer, isLoading: false } : item));
+    }, 1200);
+  };
+
+  return (
+    <div className="lp">
+      <div className="lp-header">
+        <div className="lp-tabs">
+          <button className={`lp-tab ${tab === 'chat' ? 'active' : ''}`} onClick={() => setTab('chat')}>
+            💬 채팅
+          </button>
+          <button className={`lp-tab ${tab === 'faq' ? 'active' : ''}`} onClick={() => setTab('faq')}>
+            {isScheduled ? '🤖 AI Q&A' : '❓ Q&A 모음'}
+            {!isScheduled && <span className="faq-count">{liveFaqs.length}</span>}
+          </button>
+        </div>
+        {!isScheduled && (
+          <button
+            className={`ws-btn ${wsConnected ? 'connected' : 'disconnected'}`}
+            onClick={onToggleWs}
+            disabled={!areScriptsReady && !wsConnected}
+          >
+            {wsConnected ? '● 연결됨' : '연결'}
+          </button>
+        )}
+      </div>
+
+      {tab === 'chat' ? (
+        <>
+          {isScheduled && (
+            <div className="lp-rehearsal-banner">🎬 리허설 모드 · 방송 시작 전입니다</div>
+          )}
+          <div className="lp-messages">
+            {messages.length === 0 ? (
+              <div className="lp-empty">{isScheduled ? '리허설 채팅을 시작해보세요!' : '채팅을 시작해보세요!'}</div>
+            ) : (
+              messages.map((msg) => (
+                <div key={msg.id} className="msg">
+                  <div className="msg-header">
+                    <span className="msg-nick">{msg.nickname}</span>
+                    <span className="msg-time">{msg.timestamp.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}</span>
+                  </div>
+                  <div className="msg-text">{msg.text}</div>
+                </div>
+              ))
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+          <div className="lp-nick-row">
+            <span className="lp-nick-label">닉네임</span>
+            <input className="lp-nick-input" value={nickname} onChange={(e) => setNickname(e.target.value)} maxLength={20} />
+          </div>
+          <div className="lp-input-row">
+            <input
+              className="lp-input"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyPress={handleKey}
+              placeholder={isScheduled ? '리허설 메시지를 입력하세요...' : '메시지를 입력하세요...'}
+            />
+            <button className="lp-send" onClick={onSend} disabled={!inputValue.trim()}>전송</button>
+          </div>
+        </>
+      ) : isScheduled ? (
+        /* 예정: AI Q&A 탭 */
+        <>
+          <div className="lp-faq-body">
+            <div className="lp-faq-info">방송 전 궁금한 점을 AI에게 물어보세요.</div>
+            {aiQnaList.map((item) => (
+              <div key={item.id} className="qna-item">
+                <div className="qna-row">
+                  <span className="qna-badge q">Q</span>
+                  <span className="qna-text">{item.question}</span>
+                </div>
+                <div className="qna-row">
+                  <span className="qna-badge a">AI</span>
+                  {item.isLoading ? (
+                    <span className="qna-loading">답변 생성 중<span className="dots" /></span>
+                  ) : (
+                    <span className="qna-text answer">{item.answer}</span>
+                  )}
+                </div>
+              </div>
+            ))}
+            <div ref={faqBottomRef} />
+          </div>
+          <div className="lp-input-row">
+            <input
+              className="lp-input"
+              value={aiInput}
+              onChange={(e) => setAiInput(e.target.value)}
+              onKeyPress={(e) => e.key === 'Enter' && askAI()}
+              placeholder={`${productName}에 대해 질문해보세요...`}
+            />
+            <button className="lp-send ai" onClick={askAI} disabled={!aiInput.trim()}>질문</button>
+          </div>
+        </>
+      ) : (
+        /* 라이브: Q&A 모음 탭 */
+        <div className="lp-faq-body">
+          <div className="lp-faq-info">시청자들이 방송 중 남긴 질문들을 모아볼 수 있어요.</div>
+          {liveFaqs.map((item) => (
+            <div key={item.id} className="faq-card">
+              <div className="faq-card-top">
+                <span className="faq-asker">👤 {item.askedBy}</span>
+                <span className="faq-time">{item.timestamp.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}</span>
+              </div>
+              <div className="faq-q-text">{item.question}</div>
+            </div>
+          ))}
+          <div ref={faqBottomRef} />
+        </div>
+      )}
+
+      <style jsx>{`
+        .lp { display: flex; flex-direction: column; height: 100%; background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.08); border-radius: 14px; overflow: hidden; }
+        .lp-header { padding: 12px 16px; border-bottom: 1px solid rgba(255,255,255,0.07); display: flex; align-items: center; gap: 8px; }
+        .lp-tabs { flex: 1; display: flex; gap: 4px; }
+        .lp-tab { padding: 6px 14px; border-radius: 8px; font-size: 13px; font-weight: 600; border: none; cursor: pointer; color: #64748b; background: transparent; display: flex; align-items: center; gap: 6px; transition: all 0.15s; }
+        .lp-tab.active { background: rgba(99,102,241,0.15); color: #a5b4fc; }
+        .lp-tab:hover:not(.active) { color: #94a3b8; }
+        .faq-count { background: rgba(239,68,68,0.2); color: #fca5a5; font-size: 10px; font-weight: 700; padding: 1px 6px; border-radius: 999px; }
+        .ws-btn { font-size: 11px; font-weight: 600; padding: 4px 10px; border-radius: 999px; border: none; cursor: pointer; transition: opacity 0.2s; flex-shrink: 0; }
+        .ws-btn.connected { background: rgba(16,185,129,0.15); color: #6ee7b7; border: 1px solid rgba(16,185,129,0.3); }
+        .ws-btn.disconnected { background: rgba(99,102,241,0.12); color: #a5b4fc; border: 1px solid rgba(99,102,241,0.25); }
+        .ws-btn:hover { opacity: 0.8; }
+        .lp-messages { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 10px; scrollbar-width: thin; scrollbar-color: rgba(255,255,255,0.1) transparent; }
+        .lp-messages::-webkit-scrollbar { width: 4px; }
+        .lp-messages::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 2px; }
+        .lp-empty { color: #475569; font-size: 13px; text-align: center; margin-top: 40px; }
+        .lp-rehearsal-banner { padding: 7px 16px; background: rgba(251,191,36,0.08); border-bottom: 1px solid rgba(251,191,36,0.15); font-size: 11px; font-weight: 600; color: #fcd34d; text-align: center; letter-spacing: 0.02em; }
+        .msg { display: flex; flex-direction: column; gap: 2px; }
+        .msg-header { display: flex; align-items: center; gap: 6px; }
+        .msg-nick { font-size: 12px; font-weight: 700; color: #818cf8; }
+        .msg-time { font-size: 10px; color: #475569; }
+        .msg-text { font-size: 13px; color: #cbd5e1; line-height: 1.5; word-break: break-word; padding: 6px 10px; background: rgba(255,255,255,0.04); border-radius: 6px; }
+        .lp-nick-row { padding: 10px 16px; border-top: 1px solid rgba(255,255,255,0.06); display: flex; align-items: center; gap: 8px; }
+        .lp-nick-label { font-size: 11px; color: #64748b; white-space: nowrap; }
+        .lp-nick-input { flex: 1; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.08); border-radius: 6px; padding: 5px 10px; font-size: 12px; color: #f1f5f9; outline: none; }
+        .lp-nick-input:focus { border-color: #6366f1; }
+        .lp-input-row { padding: 12px 16px; border-top: 1px solid rgba(255,255,255,0.07); display: flex; gap: 8px; }
+        .lp-input { flex: 1; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; padding: 10px 14px; font-size: 13px; color: #f1f5f9; outline: none; }
+        .lp-input:focus { border-color: #6366f1; }
+        .lp-send { padding: 10px 16px; background: linear-gradient(135deg, #6366f1, #8b5cf6); color: white; border: none; border-radius: 8px; font-size: 13px; font-weight: 600; cursor: pointer; }
+        .lp-send.ai { background: linear-gradient(135deg, #10b981, #059669); }
+        .lp-send:disabled { opacity: 0.4; cursor: not-allowed; }
+        .lp-faq-body { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 10px; scrollbar-width: thin; scrollbar-color: rgba(255,255,255,0.1) transparent; }
+        .lp-faq-body::-webkit-scrollbar { width: 4px; }
+        .lp-faq-body::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 2px; }
+        .lp-faq-info { font-size: 12px; color: #475569; padding: 8px 12px; background: rgba(255,255,255,0.03); border-radius: 8px; text-align: center; }
+        .faq-card { padding: 12px 14px; background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.07); border-radius: 10px; display: flex; flex-direction: column; gap: 6px; }
+        .faq-card-top { display: flex; align-items: center; justify-content: space-between; }
+        .faq-asker { font-size: 11px; font-weight: 600; color: #818cf8; }
+        .faq-time { font-size: 10px; color: #475569; }
+        .faq-q-text { font-size: 13px; color: #cbd5e1; line-height: 1.55; }
+        .qna-item { display: flex; flex-direction: column; gap: 8px; padding: 12px; background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.06); border-radius: 10px; }
+        .qna-row { display: flex; align-items: flex-start; gap: 8px; }
+        .qna-badge { font-size: 10px; font-weight: 700; padding: 2px 7px; border-radius: 999px; flex-shrink: 0; margin-top: 2px; }
+        .qna-badge.q { background: rgba(99,102,241,0.2); color: #a5b4fc; border: 1px solid rgba(99,102,241,0.3); }
+        .qna-badge.a { background: rgba(16,185,129,0.15); color: #6ee7b7; border: 1px solid rgba(16,185,129,0.25); }
+        .qna-text { font-size: 13px; color: #cbd5e1; line-height: 1.6; }
+        .qna-text.answer { color: #94a3b8; }
+        .qna-loading { font-size: 13px; color: #6ee7b7; display: flex; align-items: center; gap: 4px; }
+        .dots::after { content: '...'; animation: dotanim 1.2s steps(4, end) infinite; }
+        @keyframes dotanim { 0%,100% { content: ''; } 25% { content: '.'; } 50% { content: '..'; } 75% { content: '...'; } }
+      `}</style>
+    </div>
+  );
+}
+
+// ─── 종료: AI 분석 패널 ──────────────────────────────────────────────
+function EndedAnalysisPanel() {
+  const a = MOCK_AI_ANALYSIS;
+  return (
+    <div className="ap">
+      <div className="ap-header">
+        <span className="ap-icon">📊</span>
+        <div>
+          <div className="ap-title">AI 방송 분석 리포트</div>
+          <div className="ap-sub">방송 종료 후 AI가 자동 분석한 결과입니다</div>
+        </div>
+      </div>
+      <div className="ap-body">
+        {/* 주요 지표 */}
+        <div className="ap-section">
+          <div className="ap-section-title">주요 지표</div>
+          <div className="ap-metrics">
+            <div className="ap-metric">
+              <div className="ap-metric-val">{a.peakViewers.toLocaleString()}</div>
+              <div className="ap-metric-label">최고 시청자</div>
+            </div>
+            <div className="ap-metric">
+              <div className="ap-metric-val">{a.totalMessages.toLocaleString()}</div>
+              <div className="ap-metric-label">총 채팅 수</div>
+            </div>
+            <div className="ap-metric">
+              <div className="ap-metric-val">{a.avgWatchTime}</div>
+              <div className="ap-metric-label">평균 시청 시간</div>
+            </div>
+          </div>
+        </div>
+
+        {/* 감정 분석 */}
+        <div className="ap-section">
+          <div className="ap-section-title">시청자 반응 분석</div>
+          <div className="ap-sentiment-bars">
+            <div className="ap-sent-row">
+              <span className="ap-sent-label positive">긍정</span>
+              <div className="ap-bar-wrap">
+                <div className="ap-bar" style={{ width: `${a.sentiment.positive}%`, background: 'linear-gradient(90deg, #10b981, #34d399)' }} />
+              </div>
+              <span className="ap-sent-pct">{a.sentiment.positive}%</span>
+            </div>
+            <div className="ap-sent-row">
+              <span className="ap-sent-label neutral">중립</span>
+              <div className="ap-bar-wrap">
+                <div className="ap-bar" style={{ width: `${a.sentiment.neutral}%`, background: 'linear-gradient(90deg, #6366f1, #818cf8)' }} />
+              </div>
+              <span className="ap-sent-pct">{a.sentiment.neutral}%</span>
+            </div>
+            <div className="ap-sent-row">
+              <span className="ap-sent-label negative">부정</span>
+              <div className="ap-bar-wrap">
+                <div className="ap-bar" style={{ width: `${a.sentiment.negative}%`, background: 'linear-gradient(90deg, #ef4444, #f87171)' }} />
+              </div>
+              <span className="ap-sent-pct">{a.sentiment.negative}%</span>
+            </div>
+          </div>
+        </div>
+
+        {/* 주요 키워드 */}
+        <div className="ap-section">
+          <div className="ap-section-title">주요 키워드</div>
+          <div className="ap-keywords">
+            {a.topKeywords.map((kw, i) => (
+              <span key={kw} className="ap-keyword" style={{ opacity: 1 - i * 0.1 }}>#{kw}</span>
+            ))}
+          </div>
+        </div>
+
+        {/* 자주 나온 질문 */}
+        <div className="ap-section">
+          <div className="ap-section-title">시청자 주요 질문</div>
+          <div className="ap-questions">
+            {a.topQuestions.map((q, i) => (
+              <div key={i} className="ap-question">
+                <span className="ap-q-num">{i + 1}</span>
+                <span className="ap-q-text">{q}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* AI 인사이트 */}
+        <div className="ap-section">
+          <div className="ap-section-title">AI 인사이트 & 추천</div>
+          <div className="ap-insights">
+            {a.insights.map((ins, i) => (
+              <div key={i} className="ap-insight">
+                <span className="ap-insight-dot">✦</span>
+                <span className="ap-insight-text">{ins}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <style jsx>{`
+        .ap { display: flex; flex-direction: column; height: 100%; background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.08); border-radius: 14px; overflow: hidden; }
+        .ap-header { padding: 16px 20px; border-bottom: 1px solid rgba(255,255,255,0.07); display: flex; align-items: center; gap: 12px; }
+        .ap-icon { font-size: 24px; }
+        .ap-title { font-size: 15px; font-weight: 700; color: #f1f5f9; }
+        .ap-sub { font-size: 11px; color: #64748b; margin-top: 2px; }
+        .ap-body { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 20px; scrollbar-width: thin; scrollbar-color: rgba(255,255,255,0.1) transparent; }
+        .ap-body::-webkit-scrollbar { width: 4px; }
+        .ap-body::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 2px; }
+        .ap-section { display: flex; flex-direction: column; gap: 10px; }
+        .ap-section-title { font-size: 11px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: #6366f1; }
+        .ap-metrics { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
+        .ap-metric { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.07); border-radius: 10px; padding: 12px 10px; text-align: center; }
+        .ap-metric-val { font-size: 18px; font-weight: 800; color: #f1f5f9; }
+        .ap-metric-label { font-size: 10px; color: #64748b; margin-top: 4px; }
+        .ap-sentiment-bars { display: flex; flex-direction: column; gap: 8px; }
+        .ap-sent-row { display: flex; align-items: center; gap: 8px; }
+        .ap-sent-label { font-size: 11px; font-weight: 600; width: 28px; }
+        .ap-sent-label.positive { color: #6ee7b7; }
+        .ap-sent-label.neutral { color: #a5b4fc; }
+        .ap-sent-label.negative { color: #fca5a5; }
+        .ap-bar-wrap { flex: 1; height: 8px; background: rgba(255,255,255,0.06); border-radius: 999px; overflow: hidden; }
+        .ap-bar { height: 100%; border-radius: 999px; transition: width 0.8s ease; }
+        .ap-sent-pct { font-size: 11px; font-weight: 700; color: #94a3b8; width: 30px; text-align: right; }
+        .ap-keywords { display: flex; flex-wrap: wrap; gap: 6px; }
+        .ap-keyword { font-size: 12px; font-weight: 600; color: #a5b4fc; background: rgba(99,102,241,0.1); border: 1px solid rgba(99,102,241,0.2); padding: 4px 10px; border-radius: 999px; }
+        .ap-questions { display: flex; flex-direction: column; gap: 6px; }
+        .ap-question { display: flex; align-items: flex-start; gap: 10px; padding: 10px 12px; background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.06); border-radius: 8px; }
+        .ap-q-num { font-size: 11px; font-weight: 700; color: #6366f1; background: rgba(99,102,241,0.15); width: 20px; height: 20px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+        .ap-q-text { font-size: 13px; color: #94a3b8; line-height: 1.55; }
+        .ap-insights { display: flex; flex-direction: column; gap: 8px; }
+        .ap-insight { display: flex; align-items: flex-start; gap: 8px; padding: 10px 12px; background: rgba(99,102,241,0.05); border: 1px solid rgba(99,102,241,0.15); border-radius: 8px; }
+        .ap-insight-dot { color: #6366f1; font-size: 10px; margin-top: 3px; flex-shrink: 0; }
+        .ap-insight-text { font-size: 12px; color: #94a3b8; line-height: 1.6; }
+      `}</style>
+    </div>
+  );
+}
+
+// ─── 메인 페이지 ─────────────────────────────────────────────────────
+export default function BroadcastDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+
+  const broadcast = MOCK_BROADCASTS.find((b) => b.id === id) ?? null;
+
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [inputValue, setInputValue] = useState('');
+  const [nickname, setNickname] = useState('시청자');
+  const [wsConnected, setWsConnected] = useState(false);
+  const [areScriptsReady, setAreScriptsReady] = useState(false);
+  const [viewerCount, setViewerCount] = useState(broadcast?.viewerCount ?? 0);
+  const [linkedProductIds, setLinkedProductIds] = useState<string[]>(
+    broadcast?.productId ? [broadcast.productId] : []
+  );
+  const [showProductPicker, setShowProductPicker] = useState(false);
+
+  const toggleProduct = (id: string) => {
+    setLinkedProductIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
+  const clientRef = useRef<any>(null);
+  const subRef = useRef<any>(null);
+  const seenKeysRef = useRef<Set<string>>(new Set());
+
+  const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+  const WS_BASE_URL = process.env.NEXT_PUBLIC_WS_URL || API_BASE_URL;
+
+  useEffect(() => {
+    if (broadcast?.status !== 'live') return;
+    const interval = setInterval(() => {
+      setViewerCount((prev) => Math.max(1, prev + Math.floor(Math.random() * 20) - 8));
+    }, 3000);
+    return () => clearInterval(interval);
+  }, [broadcast?.status]);
+
+  const markScriptsReady = () => {
+    if (typeof window === 'undefined') return;
+    if ((window as any).SockJS && (window as any).StompJs) setAreScriptsReady(true);
+  };
+
+  const appendMessage = (rawBody: string) => {
+    if (seenKeysRef.current.has(rawBody)) return;
+    seenKeysRef.current.add(rawBody);
+    try {
+      const p = JSON.parse(rawBody ?? '{}') as any;
+      const text = p.payload?.message ?? rawBody;
+      const nick = p.actor?.sender || p.actor?.username || '시청자';
+      const ts = p.sentAt ? new Date(p.sentAt) : new Date();
+      setMessages((prev) => [...prev, { id: Date.now() + Math.random(), nickname: nick, text, timestamp: ts }]);
+    } catch {
+      setMessages((prev) => [...prev, { id: Date.now() + Math.random(), nickname: '시청자', text: rawBody, timestamp: new Date() }]);
+    }
+  };
+
+  const disconnect = () => {
+    try { subRef.current?.unsubscribe?.(); clientRef.current?.disconnect?.(); } finally {
+      clientRef.current = null; subRef.current = null; setWsConnected(false);
+    }
+  };
+
+  const connect = () => {
+    if (!areScriptsReady) return;
+    const SockJS = (window as any).SockJS;
+    const StompJs = (window as any).StompJs;
+    if (!SockJS || !StompJs) return;
+    disconnect();
+    const socket = new SockJS(`${WS_BASE_URL}/ws`);
+    const client = StompJs.Stomp.over(socket);
+    client.debug = () => {};
+    client.connect({}, () => {
+      clientRef.current = client;
+      setWsConnected(true);
+      subRef.current = client.subscribe(`/sub/room/${id}`, (msg: any) => appendMessage(msg?.body ?? ''));
+    }, () => setWsConnected(false));
+  };
+
+  const handleToggleWs = () => wsConnected ? disconnect() : connect();
+
+  const sendMessage = () => {
+    if (!inputValue.trim()) return;
+    const nick = nickname.trim() || '시청자';
+    const text = inputValue.trim();
+    if (wsConnected && clientRef.current) {
+      try {
+        clientRef.current.send('/send/room.action', {}, JSON.stringify({
+          roomId: id, action: 'CHAT.MESSAGE',
+          actor: { userId: nick, username: nick, sender: nick },
+          payload: { message: text },
+        }));
+      } catch {
+        setMessages((prev) => [...prev, { id: Date.now(), nickname: nick, text, timestamp: new Date() }]);
+      }
+    } else {
+      setMessages((prev) => [...prev, { id: Date.now(), nickname: nick, text, timestamp: new Date() }]);
+    }
+    setInputValue('');
+  };
+
+  useEffect(() => () => { disconnect(); }, []);
+
+  if (!id) return null;
+
+  if (!broadcast) {
+    return (
+      <>
+        <Head><title>방송을 찾을 수 없음</title></Head>
+        <style jsx global>{`* { margin:0;padding:0;box-sizing:border-box; } body { font-family: -apple-system,sans-serif; background:#0f172a; color:#e2e8f0; min-height:100vh; } a { text-decoration:none;color:inherit; }`}</style>
+        <div style={{ maxWidth: 600, margin: '0 auto', padding: '80px 24px', textAlign: 'center' }}>
+          <div style={{ fontSize: 48, marginBottom: 20 }}>📡</div>
+          <h1 style={{ fontSize: 24, fontWeight: 700, color: '#f1f5f9', marginBottom: 12 }}>방송을 찾을 수 없습니다</h1>
+          <p style={{ color: '#64748b', marginBottom: 32 }}>요청하신 방송이 존재하지 않거나 삭제되었습니다.</p>
+          <Link href="/broadcasts" style={{ padding: '10px 24px', background: 'linear-gradient(135deg,#6366f1,#8b5cf6)', color: 'white', borderRadius: 8, fontSize: 14, fontWeight: 600 }}>
+            목록으로 돌아가기
+          </Link>
+        </div>
+      </>
+    );
+  }
+
+  const isLive = broadcast.status === 'live';
+  const isScheduled = broadcast.status === 'scheduled';
+
+  return (
+    <>
+      <Head><title>{broadcast.title} — Live Platform Lab</title></Head>
+      <Script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js" strategy="afterInteractive" onLoad={markScriptsReady} />
+      <Script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7/bundles/stomp.umd.min.js" strategy="afterInteractive" onLoad={markScriptsReady} />
+
+      <style jsx global>{`* { margin:0;padding:0;box-sizing:border-box; } body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:#0f172a; color:#e2e8f0; min-height:100vh; } a { text-decoration:none;color:inherit; }`}</style>
+      <style jsx>{`
+        .page { display:flex; flex-direction:column; min-height:100vh; }
+        .topbar { background:rgba(15,23,42,0.95); border-bottom:1px solid rgba(255,255,255,0.06); padding:0 24px; height:56px; display:flex; align-items:center; position:sticky; top:0; z-index:50; backdrop-filter:blur(12px); }
+        .nav { display:flex; align-items:center; gap:8px; font-size:13px; color:#64748b; }
+        .nav a:hover { color:#a5b4fc; }
+        .nav-sep { color:#334155; }
+        .nav-cur { color:#94a3b8; font-weight:500; max-width:260px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+
+        .content { flex:1; display:flex; max-width:1400px; margin:0 auto; width:100%; padding:24px; gap:24px; }
+
+        .main-col { flex:1; min-width:0; display:flex; flex-direction:column; gap:20px; }
+
+        .video-wrap { position:relative; background:#000; border-radius:14px; overflow:hidden; aspect-ratio:16/9; border:1px solid rgba(255,255,255,0.08); }
+        .video-ph { width:100%; height:100%; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:16px; background:linear-gradient(135deg,#0f172a 0%,#1e293b 100%); }
+        .video-icon { font-size:56px; opacity:0.4; }
+        .video-ph-text { font-size:15px; color:#475569; font-weight:500; }
+
+        .badge-live { position:absolute; top:16px; left:16px; display:flex; align-items:center; gap:8px; background:rgba(0,0,0,0.7); border-radius:999px; padding:6px 14px; backdrop-filter:blur(8px); }
+        .live-dot { width:8px; height:8px; border-radius:50%; background:#ef4444; animation:pulse 1.5s ease-in-out infinite; }
+        @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
+        .live-txt { font-size:12px; font-weight:700; color:#fca5a5; letter-spacing:0.05em; }
+        .viewer-badge { position:absolute; top:16px; right:16px; background:rgba(0,0,0,0.7); border-radius:999px; padding:6px 14px; font-size:13px; color:#cbd5e1; backdrop-filter:blur(8px); }
+        .status-overlay { position:absolute; top:16px; left:16px; background:rgba(0,0,0,0.7); border-radius:999px; padding:6px 14px; font-size:12px; font-weight:700; backdrop-filter:blur(8px); }
+        .status-overlay.scheduled { color:#fcd34d; }
+        .status-overlay.ended { color:#94a3b8; }
+
+        .info-card { background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); border-radius:14px; padding:24px; }
+        .info-title { font-size:22px; font-weight:700; color:#f1f5f9; margin-bottom:12px; }
+        .info-meta { display:flex; flex-wrap:wrap; align-items:center; gap:10px; margin-bottom:14px; }
+        .product-tag { background:rgba(99,102,241,0.12); border:1px solid rgba(99,102,241,0.2); color:#a5b4fc; padding:4px 12px; border-radius:999px; font-size:13px; font-weight:600; }
+        .s-badge { font-size:12px; font-weight:700; padding:4px 12px; border-radius:999px; }
+        .s-live { background:rgba(239,68,68,0.15); color:#fca5a5; border:1px solid rgba(239,68,68,0.3); }
+        .s-scheduled { background:rgba(251,191,36,0.12); color:#fcd34d; border:1px solid rgba(251,191,36,0.25); }
+        .s-ended { background:rgba(100,116,139,0.12); color:#94a3b8; border:1px solid rgba(100,116,139,0.2); }
+        .info-desc { font-size:14px; color:#94a3b8; line-height:1.7; }
+        .info-started { font-size:13px; color:#64748b; }
+
+        .product-match-section { margin-top:20px; padding-top:18px; border-top:1px solid rgba(255,255,255,0.07); display:flex; flex-direction:column; gap:10px; }
+        .product-match-header { display:flex; align-items:center; justify-content:space-between; }
+        .product-match-label { font-size:11px; font-weight:700; color:#64748b; letter-spacing:0.06em; text-transform:uppercase; display:flex; align-items:center; gap:6px; }
+        .product-count { background:rgba(99,102,241,0.2); color:#a5b4fc; font-size:10px; font-weight:700; padding:1px 7px; border-radius:999px; }
+        .btn-change-product { font-size:12px; font-weight:600; color:#6366f1; background:none; border:none; cursor:pointer; padding:2px 0; }
+        .btn-change-product:hover { color:#a5b4fc; }
+        .product-match-list { display:flex; flex-direction:column; gap:6px; }
+        .product-match-card { display:flex; align-items:center; justify-content:space-between; gap:12px; padding:10px 14px; background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); border-radius:10px; }
+        .product-match-info { display:flex; align-items:center; gap:10px; flex-wrap:wrap; flex:1; min-width:0; }
+        .product-match-name { font-size:13px; font-weight:700; color:#f1f5f9; }
+        .product-match-cat { font-size:11px; font-weight:600; padding:2px 8px; border-radius:999px; background:rgba(99,102,241,0.12); color:#a5b4fc; border:1px solid rgba(99,102,241,0.2); }
+        .product-match-price { font-size:12px; color:#64748b; }
+        .btn-remove-product { background:none; border:none; color:#475569; font-size:13px; cursor:pointer; padding:2px 4px; flex-shrink:0; line-height:1; }
+        .btn-remove-product:hover { color:#f87171; }
+        .product-match-empty { font-size:13px; color:#475569; padding:6px 0; }
+        .product-picker { display:flex; flex-direction:column; gap:4px; padding:8px; background:rgba(0,0,0,0.25); border:1px solid rgba(255,255,255,0.08); border-radius:10px; }
+        .picker-item { display:flex; align-items:center; justify-content:space-between; padding:9px 12px; border-radius:8px; cursor:pointer; transition:background 0.15s; }
+        .picker-item:hover { background:rgba(99,102,241,0.08); }
+        .picker-item.selected { background:rgba(99,102,241,0.1); }
+        .picker-item-left { display:flex; align-items:center; gap:8px; }
+        .picker-item-name { font-size:13px; font-weight:600; color:#e2e8f0; }
+        .picker-item-cat { font-size:11px; color:#64748b; }
+        .picker-item-right { display:flex; align-items:center; gap:8px; }
+        .picker-item-price { font-size:12px; color:#64748b; }
+        .picker-check { font-size:12px; font-weight:700; color:#475569; width:16px; text-align:center; }
+        .picker-check.on { color:#6366f1; }
+
+        .side-col { width:360px; flex-shrink:0; height:calc(100vh - 104px); position:sticky; top:80px; }
+
+        @media (max-width:900px) {
+          .content { flex-direction:column; padding:16px; }
+          .side-col { width:100%; height:520px; position:static; }
+        }
+      `}</style>
+
+      <div className="page">
+        <div className="topbar">
+          <nav className="nav">
+            <Link href="/">홈</Link>
+            <span className="nav-sep">/</span>
+            <Link href="/broadcasts">방송 목록</Link>
+            <span className="nav-sep">/</span>
+            <span className="nav-cur">{broadcast.title}</span>
+          </nav>
+        </div>
+
+        <div className="content">
+          <div className="main-col">
+            {/* 영상 영역 */}
+            <div className="video-wrap">
+              <div className="video-ph">
+                <div className="video-icon">{isLive ? '📡' : isScheduled ? '🕐' : '📼'}</div>
+                <div className="video-ph-text">
+                  {isLive ? '스트리밍 연결 중...' : isScheduled ? '방송 시작 전입니다' : '방송이 종료되었습니다'}
+                </div>
+              </div>
+              {isLive && (
+                <>
+                  <div className="badge-live">
+                    <div className="live-dot" />
+                    <span className="live-txt">LIVE</span>
+                  </div>
+                  <div className="viewer-badge">👥 {viewerCount.toLocaleString()}명 시청 중</div>
+                </>
+              )}
+              {isScheduled && <div className="status-overlay scheduled">🕐 방송 예정</div>}
+              {broadcast.status === 'ended' && (
+                <div className="status-overlay ended">
+                  종료{broadcast.startedAt && ` · ${broadcast.startedAt} 시작`}
+                  {broadcast.viewerCount && ` · ${broadcast.viewerCount.toLocaleString()}명 시청`}
+                </div>
+              )}
+            </div>
+
+            {/* 방송 정보 */}
+            <div className="info-card">
+              <h1 className="info-title">{broadcast.title}</h1>
+              <div className="info-meta">
+                <span className={`s-badge s-${broadcast.status}`}>
+                  {isLive && '● '}{statusLabel[broadcast.status]}
+                </span>
+                {broadcast.startedAt && <span className="info-started">시작 {broadcast.startedAt}</span>}
+              </div>
+              {broadcast.description && <p className="info-desc">{broadcast.description}</p>}
+
+              {/* 상품 매칭 */}
+              <div className="product-match-section">
+                <div className="product-match-header">
+                  <span className="product-match-label">
+                    연결된 상품 {linkedProductIds.length > 0 && <span className="product-count">{linkedProductIds.length}</span>}
+                  </span>
+                  {broadcast.status !== 'ended' && (
+                    <button className="btn-change-product" onClick={() => setShowProductPicker((v) => !v)}>
+                      {showProductPicker ? '닫기' : '+ 상품 추가'}
+                    </button>
+                  )}
+                </div>
+
+                {linkedProductIds.length === 0 ? (
+                  <div className="product-match-empty">연결된 상품이 없습니다.</div>
+                ) : (
+                  <div className="product-match-list">
+                    {linkedProductIds.map((pid) => {
+                      const p = MOCK_PRODUCTS.find((x) => x.id === pid);
+                      if (!p) return null;
+                      return (
+                        <div key={pid} className="product-match-card">
+                          <div className="product-match-info">
+                            <span className="product-match-name">{p.name}</span>
+                            <span className="product-match-cat">{p.category}</span>
+                            <span className="product-match-price">{p.price.toLocaleString()}원</span>
+                          </div>
+                          {broadcast.status !== 'ended' && (
+                            <button className="btn-remove-product" onClick={() => toggleProduct(pid)}>✕</button>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {broadcast.status !== 'ended' && showProductPicker && (
+                  <div className="product-picker">
+                    {MOCK_PRODUCTS.map((p) => {
+                      const isLinked = linkedProductIds.includes(p.id);
+                      return (
+                        <div
+                          key={p.id}
+                          className={`picker-item ${isLinked ? 'selected' : ''}`}
+                          onClick={() => toggleProduct(p.id)}
+                        >
+                          <div className="picker-item-left">
+                            <span className="picker-item-name">{p.name}</span>
+                            <span className="picker-item-cat">{p.category}</span>
+                          </div>
+                          <div className="picker-item-right">
+                            <span className="picker-item-price">{p.price.toLocaleString()}원</span>
+                            <span className={`picker-check ${isLinked ? 'on' : ''}`}>{isLinked ? '✓' : '+'}</span>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* 우측 패널: 상태별 */}
+          <div className="side-col">
+            {(isScheduled || isLive) && (
+              <ChatQnAPanel
+                status={broadcast.status}
+                productName={broadcast.productName}
+                messages={messages}
+                inputValue={inputValue}
+                setInputValue={setInputValue}
+                nickname={nickname}
+                setNickname={setNickname}
+                onSend={sendMessage}
+                wsConnected={wsConnected}
+                onToggleWs={handleToggleWs}
+                areScriptsReady={areScriptsReady}
+              />
+            )}
+            {broadcast.status === 'ended' && <EndedAnalysisPanel />}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web-client/pages/broadcasts/new.tsx
+++ b/web-client/pages/broadcasts/new.tsx
@@ -1,0 +1,210 @@
+import React, { useState } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+interface Product {
+  id: string;
+  name: string;
+  category: string;
+  price: number;
+  description: string;
+  embeddingStatus: 'none' | 'pending' | 'done';
+}
+
+const MOCK_PRODUCTS: Product[] = [
+  { id: 'P001', name: '워터프루프 립스틱', category: '뷰티', price: 25000, description: '24시간 지속되는 방수 립스틱. 선명한 발색과 촉촉한 보습력을 동시에.', embeddingStatus: 'done' },
+  { id: 'P002', name: '비타민C 세럼', category: '스킨케어', price: 48000, description: '고농도 비타민C 15% 함유. 미백과 탄력 개선에 효과적입니다.', embeddingStatus: 'done' },
+  { id: 'P003', name: '쿠션 파운데이션', category: '뷰티', price: 35000, description: 'SPF50+ PA++++ 자외선 차단. 촉촉한 피부 표현에 최적화된 쿠션.', embeddingStatus: 'none' },
+];
+
+export default function BroadcastNew() {
+  const router = useRouter();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [scheduledAt, setScheduledAt] = useState('');
+  const [selectedProductId, setSelectedProductId] = useState('');
+  const [errors, setErrors] = useState<{ title?: string; product?: string }>({});
+  const [isSaving, setIsSaving] = useState(false);
+
+  const validate = () => {
+    const errs: { title?: string; product?: string } = {};
+    if (!title.trim()) errs.title = '방송 제목을 입력해주세요.';
+    if (!selectedProductId) errs.product = '상품을 선택해주세요.';
+    return errs;
+  };
+
+  const handleSave = async () => {
+    const errs = validate();
+    if (Object.keys(errs).length > 0) { setErrors(errs); return; }
+    setIsSaving(true);
+    // TODO: POST /api/v1/broadcasts
+    await new Promise((r) => setTimeout(r, 700));
+    router.push('/broadcasts');
+  };
+
+  const selectedProduct = MOCK_PRODUCTS.find((p) => p.id === selectedProductId);
+
+  return (
+    <>
+      <Head><title>방송 등록 — Live Platform Lab</title></Head>
+      <style jsx global>{`* { margin:0;padding:0;box-sizing:border-box; } body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:#0f172a; color:#e2e8f0; min-height:100vh; } a { text-decoration:none;color:inherit; }`}</style>
+      <style jsx>{`
+        .container { max-width: 900px; margin: 0 auto; padding: 40px 24px; }
+        .nav { display: flex; align-items: center; gap: 8px; margin-bottom: 40px; font-size: 13px; color: #64748b; }
+        .nav a:hover { color: #a5b4fc; }
+        .nav-sep { color: #334155; }
+
+        .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 32px; }
+        .page-title { font-size: 26px; font-weight: 800; color: #f1f5f9; }
+        .header-actions { display: flex; gap: 10px; }
+        .btn-cancel { padding: 10px 22px; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); color: #94a3b8; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; transition: background 0.2s; display: inline-flex; align-items: center; }
+        .btn-cancel:hover { background: rgba(255,255,255,0.1); }
+        .btn-save { padding: 10px 28px; background: linear-gradient(135deg, #6366f1, #8b5cf6); color: white; border: none; border-radius: 8px; font-size: 14px; font-weight: 700; cursor: pointer; transition: opacity 0.2s; }
+        .btn-save:hover:not(:disabled) { opacity: 0.88; }
+        .btn-save:disabled { opacity: 0.5; cursor: not-allowed; }
+
+        .layout { display: flex; flex-direction: column; gap: 20px; }
+
+        .card { background: #1e293b; border: 1px solid rgba(255,255,255,0.1); border-radius: 16px; padding: 28px; }
+        .card-title { font-size: 15px; font-weight: 700; color: #f1f5f9; margin-bottom: 20px; }
+
+        .field { display: flex; flex-direction: column; gap: 6px; margin-bottom: 16px; }
+        .field:last-child { margin-bottom: 0; }
+        .field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+        .label { font-size: 12px; font-weight: 700; color: #64748b; letter-spacing: 0.04em; text-transform: uppercase; }
+        .input { width: 100%; padding: 11px 14px; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); border-radius: 8px; font-size: 14px; color: #f1f5f9; outline: none; transition: border-color 0.2s; font-family: inherit; }
+        .input:focus { border-color: #6366f1; background: rgba(99,102,241,0.05); }
+        .input.has-error { border-color: rgba(239,68,68,0.5); }
+        .input::placeholder { color: #334155; }
+        textarea.input { resize: vertical; min-height: 72px; line-height: 1.6; }
+        .field-error { font-size: 12px; color: #f87171; }
+
+        /* 상품 선택 */
+        .product-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+        .product-card { background: rgba(255,255,255,0.03); border: 1.5px solid rgba(255,255,255,0.08); border-radius: 12px; padding: 16px; cursor: pointer; transition: border-color 0.15s, background 0.15s; }
+        .product-card:hover { border-color: rgba(99,102,241,0.35); background: rgba(99,102,241,0.04); }
+        .product-card.selected { border-color: #6366f1; background: rgba(99,102,241,0.08); }
+        .product-card-top { display: flex; align-items: center; justify-content: space-between; margin-bottom: 6px; }
+        .product-name { font-size: 14px; font-weight: 700; color: #f1f5f9; }
+        .product-cat { font-size: 10px; font-weight: 700; padding: 2px 8px; border-radius: 999px; background: rgba(99,102,241,0.15); color: #a5b4fc; border: 1px solid rgba(99,102,241,0.25); }
+        .product-desc { font-size: 12px; color: #64748b; line-height: 1.55; margin-bottom: 10px; }
+        .product-bottom { display: flex; align-items: center; justify-content: space-between; }
+        .product-price { font-size: 13px; font-weight: 700; color: #e2e8f0; }
+        .embed-badge { font-size: 10px; font-weight: 700; padding: 2px 8px; border-radius: 999px; }
+        .embed-done { background: rgba(16,185,129,0.12); color: #6ee7b7; border: 1px solid rgba(16,185,129,0.25); }
+        .embed-none { background: rgba(100,116,139,0.12); color: #94a3b8; border: 1px solid rgba(100,116,139,0.25); }
+        .select-check { width: 18px; height: 18px; border-radius: 50%; border: 2px solid #6366f1; background: #6366f1; display: flex; align-items: center; justify-content: center; font-size: 10px; color: white; flex-shrink: 0; margin-top: 2px; }
+        .error-msg { font-size: 12px; color: #f87171; margin-top: 8px; }
+
+        /* 선택된 상품 미리보기 */
+        .selected-preview { margin-top: 16px; padding: 14px 16px; background: rgba(99,102,241,0.06); border: 1px solid rgba(99,102,241,0.2); border-radius: 10px; display: flex; align-items: center; gap: 10px; }
+        .selected-preview-label { font-size: 11px; font-weight: 700; color: #6366f1; flex-shrink: 0; }
+        .selected-preview-name { font-size: 14px; font-weight: 600; color: #f1f5f9; }
+        .selected-preview-link { margin-left: auto; font-size: 12px; color: #6366f1; font-weight: 600; flex-shrink: 0; }
+        .selected-preview-link:hover { color: #a5b4fc; }
+
+        @media (max-width: 640px) {
+          .product-grid { grid-template-columns: 1fr; }
+          .field-row { grid-template-columns: 1fr; }
+        }
+      `}</style>
+
+      <div className="container">
+        <nav className="nav">
+          <Link href="/">홈</Link>
+          <span className="nav-sep">/</span>
+          <Link href="/broadcasts">방송 목록</Link>
+          <span className="nav-sep">/</span>
+          <span style={{ color: '#94a3b8' }}>방송 등록</span>
+        </nav>
+
+        <div className="page-header">
+          <h1 className="page-title">방송 등록</h1>
+          <div className="header-actions">
+            <Link href="/broadcasts" className="btn-cancel">취소</Link>
+            <button className="btn-save" onClick={handleSave} disabled={isSaving}>
+              {isSaving ? '저장 중...' : '저장'}
+            </button>
+          </div>
+        </div>
+
+        <div className="layout">
+          {/* 방송 정보 */}
+          <div className="card">
+            <div className="card-title">방송 정보</div>
+            <div className="field">
+              <label className="label">방송 제목 *</label>
+              <input
+                className={`input ${errors.title ? 'has-error' : ''}`}
+                placeholder="예) 봄맞이 뷰티 라이브"
+                value={title}
+                onChange={(e) => { setTitle(e.target.value); setErrors((p) => ({ ...p, title: undefined })); }}
+              />
+              {errors.title && <span className="field-error">{errors.title}</span>}
+            </div>
+            <div className="field-row">
+              <div className="field">
+                <label className="label">방송 예정 시간</label>
+                <input
+                  className="input"
+                  type="datetime-local"
+                  value={scheduledAt}
+                  onChange={(e) => setScheduledAt(e.target.value)}
+                  style={{ colorScheme: 'dark' }}
+                />
+              </div>
+            </div>
+            <div className="field">
+              <label className="label">방송 설명</label>
+              <textarea
+                className="input"
+                placeholder="방송 내용을 간략하게 소개해주세요."
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={3}
+              />
+            </div>
+          </div>
+
+          {/* 상품 선택 */}
+          <div className="card">
+            <div className="card-title">상품 선택 *</div>
+            <div className="product-grid">
+              {MOCK_PRODUCTS.map((p) => (
+                <div
+                  key={p.id}
+                  className={`product-card ${selectedProductId === p.id ? 'selected' : ''}`}
+                  onClick={() => { setSelectedProductId(p.id); setErrors((prev) => ({ ...prev, product: undefined })); }}
+                >
+                  <div className="product-card-top">
+                    <span className="product-name">{p.name}</span>
+                    {selectedProductId === p.id && <span className="select-check">✓</span>}
+                  </div>
+                  <p className="product-desc">{p.description}</p>
+                  <div className="product-bottom">
+                    <span className="product-price">{p.price.toLocaleString()}원</span>
+                    <span className={`embed-badge ${p.embeddingStatus === 'done' ? 'embed-done' : 'embed-none'}`}>
+                      {p.embeddingStatus === 'done' ? '임베딩 완료' : 'AI 미등록'}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+            {errors.product && <div className="error-msg">{errors.product}</div>}
+
+            {selectedProduct && (
+              <div className="selected-preview">
+                <span className="selected-preview-label">선택됨</span>
+                <span className="selected-preview-name">{selectedProduct.name}</span>
+                <Link href={`/products/${selectedProduct.id}`} className="selected-preview-link">
+                  상품 상세 →
+                </Link>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web-client/pages/broadcasts/new.tsx
+++ b/web-client/pages/broadcasts/new.tsx
@@ -23,14 +23,15 @@ export default function BroadcastNew() {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [scheduledAt, setScheduledAt] = useState('');
-  const [selectedProductId, setSelectedProductId] = useState('');
+  const [selectedProductIds, setSelectedProductIds] = useState<string[]>([]);
+  const [showProductPicker, setShowProductPicker] = useState(false);
   const [errors, setErrors] = useState<{ title?: string; product?: string }>({});
   const [isSaving, setIsSaving] = useState(false);
 
   const validate = () => {
     const errs: { title?: string; product?: string } = {};
     if (!title.trim()) errs.title = '방송 제목을 입력해주세요.';
-    if (!selectedProductId) errs.product = '상품을 선택해주세요.';
+    if (selectedProductIds.length === 0) errs.product = '상품을 1개 이상 선택해주세요.';
     return errs;
   };
 
@@ -43,7 +44,12 @@ export default function BroadcastNew() {
     router.push('/broadcasts');
   };
 
-  const selectedProduct = MOCK_PRODUCTS.find((p) => p.id === selectedProductId);
+  const toggleProduct = (id: string) => {
+    setSelectedProductIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+    setErrors((prev) => ({ ...prev, product: undefined }));
+  };
 
   return (
     <>
@@ -58,7 +64,7 @@ export default function BroadcastNew() {
         .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 32px; }
         .page-title { font-size: 26px; font-weight: 800; color: #f1f5f9; }
         .header-actions { display: flex; gap: 10px; }
-        .btn-cancel { padding: 10px 22px; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); color: #94a3b8; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; transition: background 0.2s; display: inline-flex; align-items: center; }
+        .btn-cancel { padding: 10px 22px; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); color: #94a3b8; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; transition: background 0.2s; display: inline-flex; align-items: center; margin-top: 8px; }
         .btn-cancel:hover { background: rgba(255,255,255,0.1); }
         .btn-save { padding: 10px 28px; background: linear-gradient(135deg, #6366f1, #8b5cf6); color: white; border: none; border-radius: 8px; font-size: 14px; font-weight: 700; cursor: pointer; transition: opacity 0.2s; }
         .btn-save:hover:not(:disabled) { opacity: 0.88; }
@@ -81,31 +87,37 @@ export default function BroadcastNew() {
         .field-error { font-size: 12px; color: #f87171; }
 
         /* 상품 선택 */
-        .product-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
-        .product-card { background: rgba(255,255,255,0.03); border: 1.5px solid rgba(255,255,255,0.08); border-radius: 12px; padding: 16px; cursor: pointer; transition: border-color 0.15s, background 0.15s; }
-        .product-card:hover { border-color: rgba(99,102,241,0.35); background: rgba(99,102,241,0.04); }
-        .product-card.selected { border-color: #6366f1; background: rgba(99,102,241,0.08); }
-        .product-card-top { display: flex; align-items: center; justify-content: space-between; margin-bottom: 6px; }
-        .product-name { font-size: 14px; font-weight: 700; color: #f1f5f9; }
-        .product-cat { font-size: 10px; font-weight: 700; padding: 2px 8px; border-radius: 999px; background: rgba(99,102,241,0.15); color: #a5b4fc; border: 1px solid rgba(99,102,241,0.25); }
-        .product-desc { font-size: 12px; color: #64748b; line-height: 1.55; margin-bottom: 10px; }
-        .product-bottom { display: flex; align-items: center; justify-content: space-between; }
-        .product-price { font-size: 13px; font-weight: 700; color: #e2e8f0; }
-        .embed-badge { font-size: 10px; font-weight: 700; padding: 2px 8px; border-radius: 999px; }
-        .embed-done { background: rgba(16,185,129,0.12); color: #6ee7b7; border: 1px solid rgba(16,185,129,0.25); }
-        .embed-none { background: rgba(100,116,139,0.12); color: #94a3b8; border: 1px solid rgba(100,116,139,0.25); }
-        .select-check { width: 18px; height: 18px; border-radius: 50%; border: 2px solid #6366f1; background: #6366f1; display: flex; align-items: center; justify-content: center; font-size: 10px; color: white; flex-shrink: 0; margin-top: 2px; }
+        .product-section-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
+        .product-section-label { font-size: 15px; font-weight: 700; color: #f1f5f9; }
+        .product-count { display: inline-flex; align-items: center; justify-content: center; width: 20px; height: 20px; background: #6366f1; color: white; border-radius: 50%; font-size: 11px; font-weight: 700; margin-left: 6px; }
+        .btn-add-product { padding: 6px 14px; background: rgba(99,102,241,0.15); border: 1px solid rgba(99,102,241,0.3); color: #a5b4fc; border-radius: 7px; font-size: 13px; font-weight: 600; cursor: pointer; transition: background 0.2s; }
+        .btn-add-product:hover { background: rgba(99,102,241,0.25); }
+
+        .product-list { display: flex; flex-direction: column; gap: 8px; margin-bottom: 12px; }
+        .product-list-card { display: flex; align-items: center; justify-content: space-between; padding: 12px 14px; background: rgba(99,102,241,0.06); border: 1px solid rgba(99,102,241,0.2); border-radius: 10px; }
+        .product-list-info { display: flex; align-items: center; gap: 10px; }
+        .product-list-name { font-size: 14px; font-weight: 600; color: #f1f5f9; }
+        .product-list-cat { font-size: 10px; font-weight: 700; padding: 2px 8px; border-radius: 999px; background: rgba(99,102,241,0.15); color: #a5b4fc; border: 1px solid rgba(99,102,241,0.25); }
+        .product-list-price { font-size: 13px; font-weight: 600; color: #94a3b8; }
+        .btn-remove-product { background: none; border: none; color: #475569; font-size: 14px; cursor: pointer; padding: 2px 6px; border-radius: 4px; transition: color 0.15s, background 0.15s; }
+        .btn-remove-product:hover { color: #f87171; background: rgba(239,68,68,0.1); }
+        .product-empty { font-size: 13px; color: #475569; margin-bottom: 12px; }
+
+        .product-picker { display: flex; flex-direction: column; gap: 4px; padding: 8px; background: rgba(0,0,0,0.25); border: 1px solid rgba(255,255,255,0.08); border-radius: 10px; }
+        .picker-item { display: flex; align-items: center; justify-content: space-between; padding: 9px 12px; border-radius: 8px; cursor: pointer; transition: background 0.15s; }
+        .picker-item:hover { background: rgba(255,255,255,0.04); }
+        .picker-item.selected { background: rgba(99,102,241,0.1); }
+        .picker-item-left { display: flex; align-items: center; gap: 8px; }
+        .picker-item-name { font-size: 13px; font-weight: 600; color: #e2e8f0; }
+        .picker-item-cat { font-size: 10px; font-weight: 700; padding: 2px 7px; border-radius: 999px; background: rgba(99,102,241,0.12); color: #a5b4fc; }
+        .picker-item-right { display: flex; align-items: center; gap: 10px; }
+        .picker-item-price { font-size: 12px; color: #64748b; }
+        .picker-check { font-size: 12px; font-weight: 700; color: #475569; width: 16px; text-align: center; }
+        .picker-check.on { color: #6366f1; }
+
         .error-msg { font-size: 12px; color: #f87171; margin-top: 8px; }
 
-        /* 선택된 상품 미리보기 */
-        .selected-preview { margin-top: 16px; padding: 14px 16px; background: rgba(99,102,241,0.06); border: 1px solid rgba(99,102,241,0.2); border-radius: 10px; display: flex; align-items: center; gap: 10px; }
-        .selected-preview-label { font-size: 11px; font-weight: 700; color: #6366f1; flex-shrink: 0; }
-        .selected-preview-name { font-size: 14px; font-weight: 600; color: #f1f5f9; }
-        .selected-preview-link { margin-left: auto; font-size: 12px; color: #6366f1; font-weight: 600; flex-shrink: 0; }
-        .selected-preview-link:hover { color: #a5b4fc; }
-
         @media (max-width: 640px) {
-          .product-grid { grid-template-columns: 1fr; }
           .field-row { grid-template-columns: 1fr; }
         }
       `}</style>
@@ -169,39 +181,62 @@ export default function BroadcastNew() {
 
           {/* 상품 선택 */}
           <div className="card">
-            <div className="card-title">상품 선택 *</div>
-            <div className="product-grid">
-              {MOCK_PRODUCTS.map((p) => (
-                <div
-                  key={p.id}
-                  className={`product-card ${selectedProductId === p.id ? 'selected' : ''}`}
-                  onClick={() => { setSelectedProductId(p.id); setErrors((prev) => ({ ...prev, product: undefined })); }}
-                >
-                  <div className="product-card-top">
-                    <span className="product-name">{p.name}</span>
-                    {selectedProductId === p.id && <span className="select-check">✓</span>}
-                  </div>
-                  <p className="product-desc">{p.description}</p>
-                  <div className="product-bottom">
-                    <span className="product-price">{p.price.toLocaleString()}원</span>
-                    <span className={`embed-badge ${p.embeddingStatus === 'done' ? 'embed-done' : 'embed-none'}`}>
-                      {p.embeddingStatus === 'done' ? '임베딩 완료' : 'AI 미등록'}
-                    </span>
-                  </div>
-                </div>
-              ))}
+            <div className="product-section-header">
+              <span className="product-section-label">
+                상품 선택 *
+                {selectedProductIds.length > 0 && <span className="product-count">{selectedProductIds.length}</span>}
+              </span>
+              <button className="btn-add-product" onClick={() => setShowProductPicker((v) => !v)}>
+                {showProductPicker ? '닫기' : '+ 상품 추가'}
+              </button>
             </div>
-            {errors.product && <div className="error-msg">{errors.product}</div>}
 
-            {selectedProduct && (
-              <div className="selected-preview">
-                <span className="selected-preview-label">선택됨</span>
-                <span className="selected-preview-name">{selectedProduct.name}</span>
-                <Link href={`/products/${selectedProduct.id}`} className="selected-preview-link">
-                  상품 상세 →
-                </Link>
+            {selectedProductIds.length === 0 ? (
+              <div className="product-empty">선택된 상품이 없습니다.</div>
+            ) : (
+              <div className="product-list">
+                {selectedProductIds.map((pid) => {
+                  const p = MOCK_PRODUCTS.find((x) => x.id === pid);
+                  if (!p) return null;
+                  return (
+                    <div key={pid} className="product-list-card">
+                      <div className="product-list-info">
+                        <span className="product-list-name">{p.name}</span>
+                        <span className="product-list-cat">{p.category}</span>
+                        <span className="product-list-price">{p.price.toLocaleString()}원</span>
+                      </div>
+                      <button className="btn-remove-product" onClick={() => toggleProduct(pid)}>✕</button>
+                    </div>
+                  );
+                })}
               </div>
             )}
+
+            {showProductPicker && (
+              <div className="product-picker">
+                {MOCK_PRODUCTS.map((p) => {
+                  const isSelected = selectedProductIds.includes(p.id);
+                  return (
+                    <div
+                      key={p.id}
+                      className={`picker-item ${isSelected ? 'selected' : ''}`}
+                      onClick={() => toggleProduct(p.id)}
+                    >
+                      <div className="picker-item-left">
+                        <span className="picker-item-name">{p.name}</span>
+                        <span className="picker-item-cat">{p.category}</span>
+                      </div>
+                      <div className="picker-item-right">
+                        <span className="picker-item-price">{p.price.toLocaleString()}원</span>
+                        <span className={`picker-check ${isSelected ? 'on' : ''}`}>{isSelected ? '✓' : '+'}</span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {errors.product && <div className="error-msg">{errors.product}</div>}
           </div>
         </div>
       </div>

--- a/web-client/pages/chat.tsx
+++ b/web-client/pages/chat.tsx
@@ -1,0 +1,714 @@
+import React, { useState, useRef, useEffect } from 'react';
+import Script from 'next/script';
+
+interface ChatRoomProps {
+  title: string;
+  isMain?: boolean;
+  nickname?: string;
+  connectionStatusText?: string;
+  connectedRoomTitle?: string;
+  externalMessages?: Message[];
+  onSendMessage?: (text: string, nickname: string) => void;
+  sendDisabled?: boolean;
+}
+
+interface Message {
+  id: number;
+  nickname: string;
+  text: string;
+  timestamp: Date;
+}
+
+// API 응답 타입
+interface ApiResponse<T> {
+  data: T;
+  error: null | {
+    code: string;
+    message: string;
+  };
+}
+
+interface CreateRoomRequest {
+  title: string;
+}
+
+interface CreateRoomResponse {
+  roomId: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface RoomListItem {
+  roomId: string;
+  title: string;
+}
+
+type DemoUser = {
+  key: string;
+  userId: string;
+  username: string;
+  sender: string;
+  isMain?: boolean;
+};
+
+type ConnectionState = {
+  connected: boolean;
+  connectedRoomId: string | null;
+  error: string | null;
+};
+
+const ChatRoom: React.FC<ChatRoomProps> = ({
+  title,
+  isMain = false,
+  nickname: propNickname,
+  connectionStatusText,
+  connectedRoomTitle,
+  externalMessages,
+  onSendMessage,
+  sendDisabled = false,
+}) => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [inputValue, setInputValue] = useState('');
+  const [nickname, setNickname] = useState(propNickname || '사용자');
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  const displayedMessages = externalMessages ?? messages;
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [displayedMessages]);
+
+  const handleSend = () => {
+    if (sendDisabled) {
+      return;
+    }
+    if (inputValue.trim()) {
+      const text = inputValue.trim();
+      const nick = nickname.trim() || '사용자';
+
+      if (onSendMessage) {
+        onSendMessage(text, nick);
+      } else {
+        const newMessage: Message = {
+          id: Date.now(),
+          nickname: nick,
+          text,
+          timestamp: new Date(),
+        };
+        setMessages([...messages, newMessage]);
+      }
+      setInputValue('');
+    }
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSend();
+    }
+  };
+
+  return (
+    <div className={`chat-room ${isMain ? 'main' : ''}`}>
+      <div className={`chat-room-header ${isMain ? 'main' : ''}`}>
+        <span>{nickname}의 채팅창</span>
+        <span className="connection-right">
+          {connectedRoomTitle ? (
+            <span className="connected-room-title">{connectedRoomTitle}</span>
+          ) : null}
+          {connectionStatusText ? (
+            <span className="connection-status">{connectionStatusText}</span>
+          ) : null}
+        </span>
+      </div>
+      <div className="chat-room-messages">
+        {displayedMessages.length === 0 ? (
+          <div className="chat-room-empty">채팅 메시지가 여기에 표시됩니다...</div>
+        ) : (
+          <>
+            {displayedMessages.map((msg) => (
+              <div key={msg.id} className="chat-message">
+                <div className="chat-message-content">
+                  <span className="chat-message-nickname">{msg.nickname}</span>
+                  <span className="chat-message-separator">|</span>
+                  <span className="chat-message-text">{msg.text}</span>
+                  <span className="chat-message-time">{msg.timestamp.toLocaleTimeString()}</span>
+                </div>
+              </div>
+            ))}
+            <div ref={messagesEndRef} />
+          </>
+        )}
+      </div>
+      <div className="chat-room-input">
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyPress={handleKeyPress}
+          placeholder="메시지를 입력하세요..."
+          className="chat-input"
+          disabled={sendDisabled}
+        />
+        <button
+          onClick={handleSend}
+          className={`chat-send-btn ${isMain ? 'main' : ''}`}
+          disabled={sendDisabled}
+        >
+          전송
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default function Chat() {
+  const [selectedRoomId, setSelectedRoomId] = useState<string>('');
+  const [rooms, setRooms] = useState<RoomListItem[]>([]);
+  const [isRoomsLoading, setIsRoomsLoading] = useState(false);
+  const [roomsError, setRoomsError] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [newChatRoomTitle, setNewChatRoomTitle] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // WebSocket(STOMP) 상태 (유저별로 분리 커넥션)
+  const clientsRef = useRef<Record<string, any>>({});
+  const subsRef = useRef<Record<string, any>>({});
+  const [areWsScriptsReady, setAreWsScriptsReady] = useState(false);
+  const [mainMessages, setMainMessages] = useState<Message[]>([]);
+  const [connections, setConnections] = useState<Record<string, ConnectionState>>({});
+  const seenMessageKeysRef = useRef<Set<string>>(new Set());
+
+  // 데모용 사용자 목록 (각 채팅창 별 identity)
+  const demoUsers: DemoUser[] = [
+    { key: 'main', userId: 'main', username: 'main@example.com', sender: '메인 사용자', isMain: true },
+    { key: 'user1', userId: 'user1', username: 'user1@example.com', sender: '사용자1' },
+    { key: 'user2', userId: 'user2', username: 'user2@example.com', sender: '사용자2' },
+    { key: 'user3', userId: 'user3', username: 'user3@example.com', sender: '사용자3' },
+    { key: 'user4', userId: 'user4', username: 'user4@example.com', sender: '사용자4' },
+    { key: 'user5', userId: 'user5', username: 'user5@example.com', sender: '사용자5' },
+    { key: 'user6', userId: 'user6', username: 'user6@example.com', sender: '사용자6' },
+    { key: 'user7', userId: 'user7', username: 'user7@example.com', sender: '사용자7' },
+    { key: 'user8', userId: 'user8', username: 'user8@example.com', sender: '사용자8' },
+    { key: 'user9', userId: 'user9', username: 'user9@example.com', sender: '사용자9' },
+  ];
+
+  // API Base URL (환경 변수 또는 기본값)
+  const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+  const WS_BASE_URL = process.env.NEXT_PUBLIC_WS_URL || API_BASE_URL;
+
+  const getRooms = async (size = 50): Promise<RoomListItem[]> => {
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/v1/rooms?size=${size}`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error?.message || `채팅방 목록 조회 실패: ${response.status}`);
+      }
+
+      const apiResponse: ApiResponse<RoomListItem[]> = await response.json();
+      return apiResponse.data ?? [];
+    } catch (err) {
+      if (err instanceof TypeError && err.message === 'Failed to fetch') {
+        throw new Error(`서버에 연결할 수 없습니다. 서버가 실행 중인지 확인해주세요. (${API_BASE_URL})`);
+      }
+      throw err;
+    }
+  };
+
+  const createRoom = async (title: string): Promise<CreateRoomResponse> => {
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/v1/rooms`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error?.message || `채팅방 생성 실패: ${response.status}`);
+      }
+
+      const apiResponse: ApiResponse<CreateRoomResponse> = await response.json();
+      return apiResponse.data;
+    } catch (err) {
+      if (err instanceof TypeError && err.message === 'Failed to fetch') {
+        throw new Error(`서버에 연결할 수 없습니다. 서버가 실행 중인지 확인해주세요. (${API_BASE_URL})`);
+      }
+      throw err;
+    }
+  };
+
+  const handleCreateChatRoom = () => {
+    setIsModalOpen(true);
+    setError(null);
+  };
+
+  const markWsScriptsReady = () => {
+    if (typeof window === 'undefined') return;
+    const SockJS = (window as any).SockJS;
+    const StompJs = (window as any).StompJs;
+    if (SockJS && StompJs) {
+      setAreWsScriptsReady(true);
+    }
+  };
+
+  const disconnectUserWs = (userKey: string) => {
+    try {
+      if (subsRef.current[userKey]) {
+        subsRef.current[userKey].unsubscribe?.();
+        delete subsRef.current[userKey];
+      }
+      if (clientsRef.current[userKey]) {
+        clientsRef.current[userKey].disconnect?.();
+        delete clientsRef.current[userKey];
+      }
+    } finally {
+      setConnections((prev) => ({
+        ...prev,
+        [userKey]: { connected: false, connectedRoomId: null, error: null },
+      }));
+    }
+  };
+
+  const appendIncomingMessage = (rawBody: string) => {
+    const key = rawBody;
+    if (seenMessageKeysRef.current.has(key)) return;
+    seenMessageKeysRef.current.add(key);
+    if (seenMessageKeysRef.current.size > 500) {
+      seenMessageKeysRef.current = new Set(Array.from(seenMessageKeysRef.current).slice(-250));
+    }
+
+    try {
+      const payload = JSON.parse(rawBody ?? '{}') as {
+        roomId?: string;
+        action?: string;
+        actor?: { userId?: string; username?: string; sender?: string };
+        payload?: { message?: string };
+        sentAt?: string;
+      };
+
+      const text = payload.payload?.message ?? rawBody ?? '';
+      const nick = payload.actor?.sender || payload.actor?.username || '사용자';
+      const ts = payload.sentAt ? new Date(payload.sentAt) : new Date();
+
+      setMainMessages((prev) => [
+        ...prev,
+        { id: Date.now() + Math.random(), nickname: nick, text, timestamp: ts },
+      ]);
+    } catch {
+      setMainMessages((prev) => [
+        ...prev,
+        { id: Date.now() + Math.random(), nickname: '사용자', text: rawBody ?? '', timestamp: new Date() },
+      ]);
+    }
+  };
+
+  const connectUserWsToRoom = (userKey: string, roomId: string) => {
+    if (!areWsScriptsReady) {
+      setConnections((prev) => ({
+        ...prev,
+        [userKey]: { connected: false, connectedRoomId: null, error: 'WebSocket 라이브러리 로딩 중입니다. 잠시 후 다시 시도해주세요.' },
+      }));
+      return;
+    }
+
+    const SockJS = (window as any).SockJS;
+    const StompJs = (window as any).StompJs;
+    if (!SockJS || !StompJs) {
+      setConnections((prev) => ({
+        ...prev,
+        [userKey]: { connected: false, connectedRoomId: null, error: 'SockJS 또는 STOMP 라이브러리가 로드되지 않았습니다.' },
+      }));
+      return;
+    }
+
+    disconnectUserWs(userKey);
+
+    const socket = new SockJS(`${WS_BASE_URL}/ws`);
+    const client = StompJs.Stomp.over(socket);
+    client.debug = () => {};
+
+    client.connect(
+      {},
+      () => {
+        clientsRef.current[userKey] = client;
+        setConnections((prev) => ({
+          ...prev,
+          [userKey]: { connected: true, connectedRoomId: roomId, error: null },
+        }));
+
+        const destination = `/sub/room/${roomId}`;
+        subsRef.current[userKey] = client.subscribe(destination, (message: any) => {
+          // eslint-disable-next-line no-console
+          console.log('[STOMP MESSAGE]', destination, message?.body);
+          appendIncomingMessage(message?.body ?? '');
+        });
+      },
+      (e: any) => {
+        setConnections((prev) => ({
+          ...prev,
+          [userKey]: {
+            connected: false,
+            connectedRoomId: null,
+            error: typeof e === 'string' ? e : 'WebSocket 연결에 실패했습니다.',
+          },
+        }));
+      }
+    );
+  };
+
+  const handleConnectChatRoom = () => {
+    if (!selectedRoomId) {
+      setRoomsError('연결할 채팅방을 먼저 선택해주세요.');
+      return;
+    }
+    setRoomsError(null);
+
+    const allConnectedToSelected = demoUsers.every((u) => {
+      const s = connections[u.key];
+      return s?.connected && s.connectedRoomId === selectedRoomId;
+    });
+
+    if (allConnectedToSelected) {
+      demoUsers.forEach((u) => disconnectUserWs(u.key));
+      return;
+    }
+
+    setMainMessages([]);
+    seenMessageKeysRef.current = new Set();
+    demoUsers.forEach((u) => connectUserWsToRoom(u.key, selectedRoomId));
+  };
+
+  const sendChatMessage = (
+    text: string,
+    identity: { userId: string; username: string; sender: string }
+  ) => {
+    const userKey = identity.userId === 'main' ? 'main' : identity.userId;
+    const state = connections[userKey];
+    const client = clientsRef.current[userKey];
+
+    if (!state?.connected || !client || !state.connectedRoomId) {
+      // eslint-disable-next-line no-console
+      console.warn('WebSocket not connected. Cannot send message.');
+      return;
+    }
+
+    const messageData = {
+      roomId: state.connectedRoomId,
+      action: 'CHAT.MESSAGE',
+      actor: {
+        userId: identity.userId,
+        username: identity.username,
+        sender: identity.sender,
+      },
+      payload: { message: text },
+    };
+
+    try {
+      client.send('/send/room.action', {}, JSON.stringify(messageData));
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to send STOMP message', e);
+    }
+  };
+
+  const handleCloseModal = () => {
+    if (isLoading) return;
+    setIsModalOpen(false);
+    setNewChatRoomTitle('');
+    setError(null);
+  };
+
+  const handleSaveChatRoom = async () => {
+    const title = newChatRoomTitle.trim();
+    if (!title) {
+      setError('채팅방 제목을 입력해주세요.');
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await createRoom(title);
+      const newRoom: RoomListItem = { roomId: response.roomId, title: response.title };
+      setRooms((prev) => [newRoom, ...prev.filter((r) => r.roomId !== newRoom.roomId)]);
+      setSelectedRoomId(response.roomId);
+      handleCloseModal();
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : '채팅방 생성에 실패했습니다.';
+      setError(errorMessage);
+      // eslint-disable-next-line no-console
+      console.error('채팅방 생성 실패:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setIsRoomsLoading(true);
+      setRoomsError(null);
+      try {
+        const fetched = await getRooms(50);
+        if (cancelled) return;
+        setRooms(fetched);
+        if (fetched.length > 0) {
+          setSelectedRoomId((prev) => prev || fetched[0].roomId);
+        } else {
+          setSelectedRoomId('');
+        }
+      } catch (e) {
+        if (cancelled) return;
+        const message = e instanceof Error ? e.message : '채팅방 목록 조회에 실패했습니다.';
+        setRoomsError(message);
+      } finally {
+        if (!cancelled) setIsRoomsLoading(false);
+      }
+    };
+
+    void load();
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      demoUsers.forEach((u) => disconnectUserWs(u.key));
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !isLoading) {
+      handleSaveChatRoom();
+    }
+  };
+
+  return (
+    <>
+      <Script
+        src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"
+        strategy="afterInteractive"
+        onLoad={markWsScriptsReady}
+      />
+      <Script
+        src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7/bundles/stomp.umd.min.js"
+        strategy="afterInteractive"
+        onLoad={markWsScriptsReady}
+      />
+      <style jsx global>{`
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+          background: linear-gradient(135deg, #f0f4f8 0%, #e2e8f0 100%);
+          min-height: 100vh;
+          padding: 20px;
+        }
+        .main-container { max-width: 1400px; margin: 0 auto; }
+        .page-header {
+          background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+          color: white;
+          padding: 30px;
+          text-align: center;
+          border-radius: 12px;
+          box-shadow: 0 10px 40px rgba(0,0,0,0.1);
+          margin-bottom: 30px;
+        }
+        .page-header h1 { font-size: 28px; margin: 0; }
+        .main-content { display: flex; gap: 20px; margin-bottom: 30px; align-items: flex-start; }
+        .main-chat-wrapper { width: calc(66.67% - 6.67px); }
+        .control-panel {
+          flex: 1;
+          background: white;
+          border-radius: 12px;
+          padding: 20px;
+          box-shadow: 0 10px 40px rgba(0,0,0,0.1);
+          min-height: 400px;
+        }
+        .control-panel-title { font-size: 20px; font-weight: 600; color: #1f2937; margin-bottom: 15px; border-bottom: 2px solid #e5e7eb; padding-bottom: 10px; }
+        .control-panel-controls { display: flex; gap: 10px; align-items: center; }
+        .control-select { flex: 1; padding: 8px 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 13px; background: white; cursor: pointer; outline: none; transition: border-color 0.2s; }
+        .control-select:focus { border-color: #667eea; box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1); }
+        .btn-create { padding: 8px 16px; background: #10b981; color: white; border: none; border-radius: 6px; font-size: 13px; font-weight: 600; cursor: pointer; white-space: nowrap; transition: all 0.2s; }
+        .btn-create:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,0.15); background: #059669; }
+        .btn-connect { padding: 8px 16px; background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%); color: white; border: none; border-radius: 6px; font-size: 13px; font-weight: 600; cursor: pointer; white-space: nowrap; transition: all 0.2s; }
+        .btn-connect:hover:not(:disabled) { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,0.15); filter: brightness(0.98); }
+        .btn-connect:disabled { opacity: 0.6; cursor: not-allowed; transform: none; }
+        .sub-chat-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+        .chat-room { background: white; border-radius: 12px; box-shadow: 0 10px 40px rgba(0,0,0,0.1); display: flex; flex-direction: column; height: 200px; overflow: hidden; }
+        .chat-room.main { height: 400px; }
+        .chat-room-header { padding: 12px 16px; background: #f9fafb; color: #1f2937; font-weight: 600; font-size: 14px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+        .chat-room-header.main { background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%); color: white; font-size: 18px; }
+        .connection-status { font-size: 13px; font-weight: 600; opacity: 0.95; white-space: nowrap; }
+        .connection-right { display: inline-flex; align-items: center; gap: 10px; min-width: 0; }
+        .connected-room-title { font-size: 13px; font-weight: 600; opacity: 0.95; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 320px; }
+        .chat-room-messages { flex: 1; padding: 12px; overflow-y: auto; display: flex; flex-direction: column; gap: 8px; font-size: 11px; color: #1f2937; }
+        .chat-room.main .chat-room-messages { font-size: 14px; }
+        .chat-room-empty { color: #9ca3af; font-style: italic; font-size: 10px; text-align: center; margin-top: 20px; }
+        .chat-room.main .chat-room-empty { font-size: 13px; }
+        .chat-message { padding: 8px 12px; background: #f9fafb; border-radius: 6px; word-break: break-word; }
+        .chat-message-content { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-size: 11px; }
+        .chat-room.main .chat-message-content { font-size: 13px; }
+        .chat-message-nickname { font-weight: 600; color: #667eea; }
+        .chat-message-separator { color: #9ca3af; }
+        .chat-message-text { flex: 1; }
+        .chat-message-time { font-size: 10px; color: #9ca3af; }
+        .chat-room-input { border-top: 1px solid #e5e7eb; padding: 12px; display: flex; gap: 8px; }
+        .chat-input { flex: 1; padding: 10px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 14px; outline: none; transition: border-color 0.2s; }
+        .chat-input:focus { border-color: #667eea; box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1); }
+        .chat-send-btn { padding: 10px 20px; background: #6c757d; color: white; border: none; border-radius: 6px; font-size: 14px; font-weight: 600; cursor: pointer; transition: all 0.2s; }
+        .chat-send-btn.main { background: #6366f1; }
+        .chat-send-btn:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,0.15); }
+        .chat-send-btn.main:hover { background: #4f46e5; }
+        .chat-send-btn:not(.main):hover { background: #5a6268; }
+        .modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000; }
+        .modal-content { background: white; border-radius: 12px; padding: 30px; width: 90%; max-width: 500px; box-shadow: 0 10px 40px rgba(0,0,0,0.1); }
+        .modal-title { font-size: 24px; font-weight: 600; margin-bottom: 20px; color: #1f2937; }
+        .modal-form-group { margin-bottom: 20px; }
+        .modal-label { display: block; margin-bottom: 8px; font-size: 14px; font-weight: 600; color: #374151; }
+        .modal-input { width: 100%; padding: 12px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 14px; outline: none; transition: border-color 0.2s; }
+        .modal-input:focus { border-color: #667eea; box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1); }
+        .modal-actions { display: flex; gap: 10px; justify-content: flex-end; }
+        .btn-cancel { padding: 10px 20px; background: #6c757d; color: white; border: none; border-radius: 6px; font-size: 14px; font-weight: 600; cursor: pointer; transition: all 0.2s; }
+        .btn-cancel:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,0.15); background: #5a6268; }
+        .btn-save { padding: 10px 20px; background: #10b981; color: white; border: none; border-radius: 6px; font-size: 14px; font-weight: 600; cursor: pointer; transition: all 0.2s; }
+        .btn-save:hover:not(:disabled) { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,0.15); background: #059669; }
+        .btn-save:disabled, .btn-cancel:disabled { opacity: 0.6; cursor: not-allowed; transform: none; }
+        .modal-input:disabled { background-color: #f3f4f6; cursor: not-allowed; }
+        @media (max-width: 768px) {
+          .main-content { flex-direction: column; }
+          .main-chat-wrapper { width: 100%; }
+          .sub-chat-grid { grid-template-columns: 1fr; }
+        }
+      `}</style>
+
+      <div className="main-container">
+        <div className="page-header">
+          <h1>🚀 Live Platform Lab - 채팅방</h1>
+        </div>
+
+        <div className="main-content">
+          <div className="main-chat-wrapper">
+            <ChatRoom
+              title={rooms.find((r) => r.roomId === selectedRoomId)?.title || ''}
+              isMain={true}
+              nickname="메인 사용자"
+              connectionStatusText={connections['main']?.connected ? '연결됨' : '연결 안 됨'}
+              connectedRoomTitle={
+                connections['main']?.connectedRoomId
+                  ? rooms.find((r) => r.roomId === connections['main']?.connectedRoomId)?.title ||
+                    connections['main']?.connectedRoomId ||
+                    undefined
+                  : undefined
+              }
+              externalMessages={mainMessages}
+              onSendMessage={(text) =>
+                sendChatMessage(text, { userId: 'main', username: 'main@example.com', sender: '메인 사용자' })
+              }
+              sendDisabled={!connections['main']?.connected}
+            />
+          </div>
+
+          <div className="control-panel">
+            <div className="control-panel-title">채팅방 선택</div>
+            <div className="control-panel-controls">
+              <select
+                value={selectedRoomId}
+                onChange={(e) => setSelectedRoomId(e.target.value)}
+                className="control-select"
+                disabled={isRoomsLoading || rooms.length === 0}
+              >
+                {isRoomsLoading ? (
+                  <option value="">불러오는 중...</option>
+                ) : rooms.length === 0 ? (
+                  <option value="">채팅방이 없습니다</option>
+                ) : (
+                  rooms.map((room) => (
+                    <option key={room.roomId} value={room.roomId}>{room.title}</option>
+                  ))
+                )}
+              </select>
+              <button onClick={handleCreateChatRoom} className="btn-create">생성</button>
+              <button
+                onClick={handleConnectChatRoom}
+                className="btn-connect"
+                disabled={isRoomsLoading || rooms.length === 0 || !selectedRoomId || !areWsScriptsReady}
+              >
+                {demoUsers.every((u) => connections[u.key]?.connected && connections[u.key]?.connectedRoomId === selectedRoomId)
+                  ? '연결 끊기'
+                  : '연결'}
+              </button>
+            </div>
+            {roomsError && (
+              <div style={{ marginTop: 8, fontSize: 13, color: '#ef4444' }}>{roomsError}</div>
+            )}
+          </div>
+        </div>
+
+        <div className="sub-chat-grid">
+          {demoUsers
+            .filter((u) => !u.isMain)
+            .map((u) => (
+              <ChatRoom
+                key={u.userId}
+                title={rooms.find((r) => r.roomId === selectedRoomId)?.title || ''}
+                nickname={u.sender}
+                connectionStatusText={connections[u.key]?.connected ? '연결됨' : '연결 안 됨'}
+                connectedRoomTitle={
+                  connections[u.key]?.connectedRoomId
+                    ? rooms.find((r) => r.roomId === connections[u.key]?.connectedRoomId)?.title ||
+                      connections[u.key]?.connectedRoomId ||
+                      undefined
+                    : undefined
+                }
+                externalMessages={mainMessages}
+                onSendMessage={(text) => sendChatMessage(text, u)}
+                sendDisabled={!connections[u.key]?.connected}
+              />
+            ))}
+        </div>
+      </div>
+
+      {isModalOpen && (
+        <div className="modal-overlay" onClick={handleCloseModal}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h2 className="modal-title">채팅방 생성</h2>
+            <div className="modal-form-group">
+              <label className="modal-label">채팅방 제목</label>
+              <input
+                type="text"
+                value={newChatRoomTitle}
+                onChange={(e) => { setNewChatRoomTitle(e.target.value); setError(null); }}
+                onKeyPress={handleKeyPress}
+                placeholder="채팅방 제목을 입력하세요"
+                className="modal-input"
+                autoFocus
+                disabled={isLoading}
+              />
+              {error && (
+                <div style={{ color: '#ef4444', fontSize: '14px', marginTop: '8px' }}>{error}</div>
+              )}
+            </div>
+            <div className="modal-actions">
+              <button onClick={handleCloseModal} className="btn-cancel" disabled={isLoading}>취소</button>
+              <button onClick={handleSaveChatRoom} className="btn-save" disabled={isLoading || !newChatRoomTitle.trim()}>
+                {isLoading ? '생성 중...' : '저장'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web-client/pages/index.tsx
+++ b/web-client/pages/index.tsx
@@ -1,1168 +1,341 @@
-import React, { useState, useRef, useEffect } from 'react';
-import Script from 'next/script';
+import React from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
 
-interface ChatRoomProps {
-  title: string;
-  isMain?: boolean;
-  nickname?: string;
-  connectionStatusText?: string;
-  connectedRoomTitle?: string;
-  externalMessages?: Message[];
-  onSendMessage?: (text: string, nickname: string) => void;
-  sendDisabled?: boolean;
-}
+const features = [
+  {
+    icon: '📄',
+    title: 'PDF 상품 임베딩',
+    description: '상품 정보 PDF를 업로드하면 자동으로 벡터화하여 AI 검색에 활용합니다.',
+    status: 'planned',
+  },
+  {
+    icon: '🤖',
+    title: 'AI 고객 Q&A',
+    description: '방송 중 고객 질문에 RAG 기반으로 상품 정보를 근거로 한 답변을 제공합니다.',
+    status: 'planned',
+  },
+  {
+    icon: '💬',
+    title: '실시간 채팅',
+    description: 'WebSocket/STOMP 기반의 라이브 채팅으로 고객과 실시간으로 소통합니다.',
+    status: 'done',
+  },
+  {
+    icon: '📊',
+    title: '호스트 인사이트',
+    description: '채팅 메시지를 분석하여 호스트에게 실시간 반응 및 인사이트를 제공합니다.',
+    status: 'planned',
+  },
+];
 
-interface Message {
-  id: number;
-  nickname: string;
-  text: string;
-  timestamp: Date;
-}
-
-// API 응답 타입
-interface ApiResponse<T> {
-  data: T;
-  error: null | {
-    code: string;
-    message: string;
-  };
-}
-
-interface CreateRoomRequest {
-  title: string;
-}
-
-interface CreateRoomResponse {
-  roomId: string;
-  title: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface RoomListItem {
-  roomId: string;
-  title: string;
-}
-
-type DemoUser = {
-  key: string;
-  userId: string;
-  username: string;
-  sender: string;
-  isMain?: boolean;
-};
-
-type ConnectionState = {
-  connected: boolean;
-  connectedRoomId: string | null;
-  error: string | null;
-};
-
-const ChatRoom: React.FC<ChatRoomProps> = ({
-  title,
-  isMain = false,
-  nickname: propNickname,
-  connectionStatusText,
-  connectedRoomTitle,
-  externalMessages,
-  onSendMessage,
-  sendDisabled = false,
-}) => {
-  const [messages, setMessages] = useState<Message[]>([]);
-  const [inputValue, setInputValue] = useState('');
-  const [nickname, setNickname] = useState(propNickname || '사용자');
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-
-  const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  };
-
-  const displayedMessages = externalMessages ?? messages;
-
-  useEffect(() => {
-    scrollToBottom();
-  }, [displayedMessages]);
-
-  const handleSend = () => {
-    if (sendDisabled) {
-      return;
-    }
-    if (inputValue.trim()) {
-      const text = inputValue.trim();
-      const nick = nickname.trim() || '사용자';
-
-      if (onSendMessage) {
-        onSendMessage(text, nick);
-      } else {
-        const newMessage: Message = {
-          id: Date.now(),
-          nickname: nick,
-          text,
-          timestamp: new Date(),
-        };
-        setMessages([...messages, newMessage]);
-      }
-      setInputValue('');
-    }
-  };
-
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      handleSend();
-    }
-  };
-
-  return (
-    <div className={`chat-room ${isMain ? 'main' : ''}`}>
-      <div className={`chat-room-header ${isMain ? 'main' : ''}`}>
-        <span>{nickname}의 채팅창</span>
-        <span className="connection-right">
-          {connectedRoomTitle ? (
-            <span className="connected-room-title">{connectedRoomTitle}</span>
-          ) : null}
-          {connectionStatusText ? (
-            <span className="connection-status">{connectionStatusText}</span>
-          ) : null}
-        </span>
-      </div>
-      <div className="chat-room-messages">
-        {displayedMessages.length === 0 ? (
-          <div className="chat-room-empty">채팅 메시지가 여기에 표시됩니다...</div>
-        ) : (
-          <>
-            {displayedMessages.map((msg) => (
-              <div key={msg.id} className="chat-message">
-                <div className="chat-message-content">
-                  <span className="chat-message-nickname">{msg.nickname}</span>
-                  <span className="chat-message-separator">|</span>
-                  <span className="chat-message-text">{msg.text}</span>
-                  <span className="chat-message-time">{msg.timestamp.toLocaleTimeString()}</span>
-                </div>
-              </div>
-            ))}
-            <div ref={messagesEndRef} />
-          </>
-        )}
-      </div>
-      <div className="chat-room-input">
-        <input
-          type="text"
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          onKeyPress={handleKeyPress}
-          placeholder="메시지를 입력하세요..."
-          className="chat-input"
-          disabled={sendDisabled}
-        />
-        <button
-          onClick={handleSend}
-          className={`chat-send-btn ${isMain ? 'main' : ''}`}
-          disabled={sendDisabled}
-        >
-          전송
-        </button>
-      </div>
-    </div>
-  );
-};
+const techStack = [
+  { name: 'Spring Boot', desc: 'Java 백엔드' },
+  { name: 'Spring AI', desc: 'LLM / RAG' },
+  { name: 'ElasticSearch', desc: '벡터 + 키워드 검색' },
+  { name: 'STOMP / WebSocket', desc: '실시간 채팅' },
+  { name: 'Redis', desc: '캐싱' },
+  { name: 'Next.js', desc: '프론트엔드' },
+];
 
 export default function Home() {
-  const [selectedRoomId, setSelectedRoomId] = useState<string>('');
-  const [rooms, setRooms] = useState<RoomListItem[]>([]);
-  const [isRoomsLoading, setIsRoomsLoading] = useState(false);
-  const [roomsError, setRoomsError] = useState<string | null>(null);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [newChatRoomTitle, setNewChatRoomTitle] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  // WebSocket(STOMP) 상태 (유저별로 분리 커넥션)
-  const clientsRef = useRef<Record<string, any>>({});
-  const subsRef = useRef<Record<string, any>>({});
-  const [areWsScriptsReady, setAreWsScriptsReady] = useState(false);
-  const [mainMessages, setMainMessages] = useState<Message[]>([]);
-  const [connections, setConnections] = useState<Record<string, ConnectionState>>({});
-  const seenMessageKeysRef = useRef<Set<string>>(new Set());
-
-  // 데모용 사용자 목록 (각 채팅창 별 identity)
-  const demoUsers: DemoUser[] = [
-    { key: 'main', userId: 'main', username: 'main@example.com', sender: '메인 사용자', isMain: true },
-    { key: 'user1', userId: 'user1', username: 'user1@example.com', sender: '사용자1' },
-    { key: 'user2', userId: 'user2', username: 'user2@example.com', sender: '사용자2' },
-    { key: 'user3', userId: 'user3', username: 'user3@example.com', sender: '사용자3' },
-    { key: 'user4', userId: 'user4', username: 'user4@example.com', sender: '사용자4' },
-    { key: 'user5', userId: 'user5', username: 'user5@example.com', sender: '사용자5' },
-    { key: 'user6', userId: 'user6', username: 'user6@example.com', sender: '사용자6' },
-    { key: 'user7', userId: 'user7', username: 'user7@example.com', sender: '사용자7' },
-    { key: 'user8', userId: 'user8', username: 'user8@example.com', sender: '사용자8' },
-    { key: 'user9', userId: 'user9', username: 'user9@example.com', sender: '사용자9' },
-  ];
-
-  // API Base URL (환경 변수 또는 기본값)
-  const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
-  const WS_BASE_URL = process.env.NEXT_PUBLIC_WS_URL || API_BASE_URL;
-
-  // 채팅방 목록 조회 API 호출 함수
-  const getRooms = async (size = 50): Promise<RoomListItem[]> => {
-    try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/rooms?size=${size}`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(
-          errorData.error?.message || `채팅방 목록 조회 실패: ${response.status}`
-        );
-      }
-
-      const apiResponse: ApiResponse<RoomListItem[]> = await response.json();
-      return apiResponse.data ?? [];
-    } catch (err) {
-      if (err instanceof TypeError && err.message === 'Failed to fetch') {
-        throw new Error(
-          `서버에 연결할 수 없습니다. 서버가 실행 중인지 확인해주세요. (${API_BASE_URL})`
-        );
-      }
-      throw err;
-    }
-  };
-
-  // 채팅방 생성 API 호출 함수
-  const createRoom = async (title: string): Promise<CreateRoomResponse> => {
-    try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/rooms`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ title }),
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(
-          errorData.error?.message || `채팅방 생성 실패: ${response.status}`
-        );
-      }
-
-      const apiResponse: ApiResponse<CreateRoomResponse> = await response.json();
-      return apiResponse.data;
-    } catch (err) {
-      // 네트워크 에러 또는 기타 에러 처리
-      if (err instanceof TypeError && err.message === 'Failed to fetch') {
-        throw new Error(
-          `서버에 연결할 수 없습니다. 서버가 실행 중인지 확인해주세요. (${API_BASE_URL})`
-        );
-      }
-      throw err;
-    }
-  };
-
-  const handleCreateChatRoom = () => {
-    setIsModalOpen(true);
-    setError(null); // 모달 열 때 에러 초기화
-  };
-
-  const markWsScriptsReady = () => {
-    if (typeof window === 'undefined') return;
-    const SockJS = (window as any).SockJS;
-    const StompJs = (window as any).StompJs;
-    if (SockJS && StompJs) {
-      setAreWsScriptsReady(true);
-    }
-  };
-
-  const disconnectUserWs = (userKey: string) => {
-    try {
-      if (subsRef.current[userKey]) {
-        subsRef.current[userKey].unsubscribe?.();
-        delete subsRef.current[userKey];
-      }
-      if (clientsRef.current[userKey]) {
-        clientsRef.current[userKey].disconnect?.();
-        delete clientsRef.current[userKey];
-      }
-    } finally {
-      setConnections((prev) => ({
-        ...prev,
-        [userKey]: { connected: false, connectedRoomId: null, error: null },
-      }));
-    }
-  };
-
-  const appendIncomingMessage = (rawBody: string) => {
-    // 여러 커넥션에서 동일 브로드캐스트를 N번 받을 수 있어서 dedupe
-    const key = rawBody;
-    if (seenMessageKeysRef.current.has(key)) {
-      return;
-    }
-    seenMessageKeysRef.current.add(key);
-    if (seenMessageKeysRef.current.size > 500) {
-      // 간단한 사이즈 제한 (테스트용)
-      seenMessageKeysRef.current = new Set(Array.from(seenMessageKeysRef.current).slice(-250));
-    }
-
-    try {
-      const payload = JSON.parse(rawBody ?? '{}') as {
-        roomId?: string;
-        action?: string;
-        actor?: { userId?: string; username?: string; sender?: string };
-        payload?: { message?: string };
-        sentAt?: string;
-      };
-
-      const text = payload.payload?.message ?? rawBody ?? '';
-      const nick = payload.actor?.sender || payload.actor?.username || '사용자';
-      const ts = payload.sentAt ? new Date(payload.sentAt) : new Date();
-
-      setMainMessages((prev) => [
-        ...prev,
-        {
-          id: Date.now() + Math.random(),
-          nickname: nick,
-          text,
-          timestamp: ts,
-        },
-      ]);
-    } catch {
-      setMainMessages((prev) => [
-        ...prev,
-        {
-          id: Date.now() + Math.random(),
-          nickname: '사용자',
-          text: rawBody ?? '',
-          timestamp: new Date(),
-        },
-      ]);
-    }
-  };
-
-  const connectUserWsToRoom = (userKey: string, roomId: string) => {
-    if (!areWsScriptsReady) {
-      setConnections((prev) => ({
-        ...prev,
-        [userKey]: {
-          connected: false,
-          connectedRoomId: null,
-          error: 'WebSocket 라이브러리 로딩 중입니다. 잠시 후 다시 시도해주세요.',
-        },
-      }));
-      return;
-    }
-
-    const SockJS = (window as any).SockJS;
-    const StompJs = (window as any).StompJs;
-    if (!SockJS || !StompJs) {
-      setConnections((prev) => ({
-        ...prev,
-        [userKey]: {
-          connected: false,
-          connectedRoomId: null,
-          error: 'SockJS 또는 STOMP 라이브러리가 로드되지 않았습니다.',
-        },
-      }));
-      return;
-    }
-
-    // 기존 연결 정리 후 재연결
-    disconnectUserWs(userKey);
-
-    const wsEndpoint = `${WS_BASE_URL}/ws`;
-
-    const socket = new SockJS(wsEndpoint);
-    const client = StompJs.Stomp.over(socket);
-    client.debug = () => {};
-
-    client.connect(
-      {},
-      () => {
-        clientsRef.current[userKey] = client;
-        setConnections((prev) => ({
-          ...prev,
-          [userKey]: { connected: true, connectedRoomId: roomId, error: null },
-        }));
-
-        const destination = `/sub/room/${roomId}`;
-        subsRef.current[userKey] = client.subscribe(destination, (message: any) => {
-          // eslint-disable-next-line no-console
-          console.log('[STOMP MESSAGE]', destination, message?.body);
-          appendIncomingMessage(message?.body ?? '');
-        });
-      },
-      (e: any) => {
-        setConnections((prev) => ({
-          ...prev,
-          [userKey]: {
-            connected: false,
-            connectedRoomId: null,
-            error: typeof e === 'string' ? e : 'WebSocket 연결에 실패했습니다.',
-          },
-        }));
-      }
-    );
-  };
-
-  const handleConnectChatRoom = () => {
-    if (!selectedRoomId) {
-      setRoomsError('연결할 채팅방을 먼저 선택해주세요.');
-      return;
-    }
-    setRoomsError(null);
-
-    const allConnectedToSelected = demoUsers.every((u) => {
-      const s = connections[u.key];
-      return s?.connected && s.connectedRoomId === selectedRoomId;
-    });
-
-    if (allConnectedToSelected) {
-      // 전체 연결 끊기
-      demoUsers.forEach((u) => disconnectUserWs(u.key));
-      return;
-    }
-
-    // 전체 유저를 각각 별도 커넥션으로 연결
-    setMainMessages([]);
-    seenMessageKeysRef.current = new Set();
-    demoUsers.forEach((u) => connectUserWsToRoom(u.key, selectedRoomId));
-  };
-
-  const sendChatMessage = (
-    text: string,
-    identity: { userId: string; username: string; sender: string }
-  ) => {
-    const userKey = identity.userId === 'main' ? 'main' : identity.userId;
-    const state = connections[userKey];
-    const client = clientsRef.current[userKey];
-
-    if (!state?.connected || !client || !state.connectedRoomId) {
-      // 연결 상태 표시는 헤더에만 하기로 했으니, 여기서는 조용히 로그만 남김
-      // eslint-disable-next-line no-console
-      console.warn('WebSocket not connected. Cannot send message.');
-      return;
-    }
-
-    const messageData = {
-      roomId: state.connectedRoomId,
-      action: 'CHAT.MESSAGE',
-      actor: {
-        userId: identity.userId,
-        username: identity.username,
-        sender: identity.sender,
-      },
-      payload: { message: text },
-    };
-
-    try {
-      client.send('/send/room.action', {}, JSON.stringify(messageData));
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.error('Failed to send STOMP message', e);
-    }
-  };
-
-  const handleCloseModal = () => {
-    if (isLoading) return; // 로딩 중에는 닫기 방지
-    setIsModalOpen(false);
-    setNewChatRoomTitle('');
-    setError(null);
-  };
-
-  const handleSaveChatRoom = async () => {
-    const title = newChatRoomTitle.trim();
-    
-    if (!title) {
-      setError('채팅방 제목을 입력해주세요.');
-      return;
-    }
-
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      // API 호출
-      const response = await createRoom(title);
-      
-      // 성공 시 채팅방 목록에 추가
-      const newRoom: RoomListItem = { roomId: response.roomId, title: response.title };
-      setRooms((prev) => [newRoom, ...prev.filter((r) => r.roomId !== newRoom.roomId)]);
-      setSelectedRoomId(response.roomId);
-      
-      // 모달 닫기
-      handleCloseModal();
-    } catch (err) {
-      // 에러 처리
-      const errorMessage = err instanceof Error ? err.message : '채팅방 생성에 실패했습니다.';
-      setError(errorMessage);
-      console.error('채팅방 생성 실패:', err);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const load = async () => {
-      setIsRoomsLoading(true);
-      setRoomsError(null);
-      try {
-        const fetched = await getRooms(50);
-        if (cancelled) return;
-
-        setRooms(fetched);
-        if (fetched.length > 0) {
-          setSelectedRoomId((prev) => prev || fetched[0].roomId);
-        } else {
-          setSelectedRoomId('');
-        }
-      } catch (e) {
-        if (cancelled) return;
-        const message =
-          e instanceof Error ? e.message : '채팅방 목록 조회에 실패했습니다.';
-        setRoomsError(message);
-      } finally {
-        if (!cancelled) {
-          setIsRoomsLoading(false);
-        }
-      }
-    };
-
-    void load();
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // 페이지 이탈/언마운트 시 연결 정리
-  useEffect(() => {
-    return () => {
-      demoUsers.forEach((u) => disconnectUserWs(u.key));
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && !isLoading) {
-      handleSaveChatRoom();
-    }
-  };
-
   return (
     <>
-      <Script
-        src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"
-        strategy="afterInteractive"
-        onLoad={markWsScriptsReady}
-      />
-      <Script
-        src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7/bundles/stomp.umd.min.js"
-        strategy="afterInteractive"
-        onLoad={markWsScriptsReady}
-      />
+      <Head>
+        <title>Live Platform Lab</title>
+        <meta name="description" content="AI 기반 라이브 커머스 플랫폼" />
+      </Head>
+
       <style jsx global>{`
-        * {
-          margin: 0;
-          padding: 0;
-          box-sizing: border-box;
-        }
-        
+        * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
-          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-          background: linear-gradient(135deg, #f0f4f8 0%, #e2e8f0 100%);
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+          background: #0f172a;
+          color: #e2e8f0;
           min-height: 100vh;
-          padding: 20px;
         }
-        
-        .main-container {
-          max-width: 1400px;
+        a { text-decoration: none; color: inherit; }
+      `}</style>
+
+      <style jsx>{`
+        .container {
+          max-width: 1100px;
           margin: 0 auto;
-        }
-        
-        .page-header {
-          background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
-          color: white;
-          padding: 30px;
-          text-align: center;
-          border-radius: 12px;
-          box-shadow: 0 10px 40px rgba(0,0,0,0.1);
-          margin-bottom: 30px;
-        }
-        
-        .page-header h1 {
-          font-size: 28px;
-          margin: 0;
-        }
-        
-        .main-content {
-          display: flex;
-          gap: 20px;
-          margin-bottom: 30px;
-          align-items: flex-start;
-        }
-        
-        .main-chat-wrapper {
-          width: calc(66.67% - 6.67px);
-        }
-        
-        .control-panel {
-          flex: 1;
-          background: white;
-          border-radius: 12px;
-          padding: 20px;
-          box-shadow: 0 10px 40px rgba(0,0,0,0.1);
-          min-height: 400px;
-        }
-        
-        .control-panel-title {
-          font-size: 20px;
-          font-weight: 600;
-          color: #1f2937;
-          margin-bottom: 15px;
-          border-bottom: 2px solid #e5e7eb;
-          padding-bottom: 10px;
-        }
-        
-        .control-panel-controls {
-          display: flex;
-          gap: 10px;
-          align-items: center;
-        }
-        
-        .control-select {
-          flex: 1;
-          padding: 8px 12px;
-          border: 1px solid #d1d5db;
-          border-radius: 6px;
-          font-size: 13px;
-          background: white;
-          cursor: pointer;
-          outline: none;
-          transition: border-color 0.2s;
-        }
-        
-        .control-select:focus {
-          border-color: #667eea;
-          box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
-        }
-        
-        .btn-create {
-          padding: 8px 16px;
-          background: #10b981;
-          color: white;
-          border: none;
-          border-radius: 6px;
-          font-size: 13px;
-          font-weight: 600;
-          cursor: pointer;
-          white-space: nowrap;
-          transition: all 0.2s;
-        }
-        
-        .btn-create:hover {
-          transform: translateY(-2px);
-          box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-          background: #059669;
+          padding: 60px 24px;
         }
 
-        .btn-connect {
-          padding: 8px 16px;
-          background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
-          color: white;
-          border: none;
-          border-radius: 6px;
+        /* Hero */
+        .hero {
+          text-align: center;
+          margin-bottom: 80px;
+        }
+        .hero-badge {
+          display: inline-block;
+          background: rgba(99, 102, 241, 0.15);
+          border: 1px solid rgba(99, 102, 241, 0.4);
+          color: #a5b4fc;
           font-size: 13px;
           font-weight: 600;
-          cursor: pointer;
-          white-space: nowrap;
-          transition: all 0.2s;
+          padding: 6px 16px;
+          border-radius: 999px;
+          margin-bottom: 24px;
+          letter-spacing: 0.05em;
         }
-        
-        .btn-connect:hover:not(:disabled) {
+        .hero h1 {
+          font-size: 52px;
+          font-weight: 800;
+          line-height: 1.15;
+          margin-bottom: 20px;
+          background: linear-gradient(135deg, #e2e8f0 0%, #a5b4fc 100%);
+          -webkit-background-clip: text;
+          -webkit-text-fill-color: transparent;
+          background-clip: text;
+        }
+        .hero p {
+          font-size: 18px;
+          color: #94a3b8;
+          max-width: 560px;
+          margin: 0 auto 40px;
+          line-height: 1.7;
+        }
+        .hero-actions {
+          display: flex;
+          gap: 16px;
+          justify-content: center;
+          flex-wrap: wrap;
+        }
+        .btn-primary {
+          padding: 14px 32px;
+          background: linear-gradient(135deg, #6366f1, #8b5cf6);
+          color: white;
+          border-radius: 10px;
+          font-size: 15px;
+          font-weight: 600;
+          transition: opacity 0.2s, transform 0.2s;
+        }
+        .btn-primary:hover {
+          opacity: 0.9;
           transform: translateY(-2px);
-          box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-          filter: brightness(0.98);
         }
-        
-        .btn-connect:disabled {
-          opacity: 0.6;
-          cursor: not-allowed;
-          transform: none;
+        .btn-secondary {
+          padding: 14px 32px;
+          background: rgba(255, 255, 255, 0.05);
+          border: 1px solid rgba(255, 255, 255, 0.12);
+          color: #cbd5e1;
+          border-radius: 10px;
+          font-size: 15px;
+          font-weight: 600;
+          transition: background 0.2s, transform 0.2s;
         }
-        
-        .sub-chat-grid {
+        .btn-secondary:hover {
+          background: rgba(255, 255, 255, 0.1);
+          transform: translateY(-2px);
+        }
+
+        /* Section title */
+        .section-title {
+          font-size: 13px;
+          font-weight: 700;
+          letter-spacing: 0.1em;
+          color: #6366f1;
+          text-transform: uppercase;
+          margin-bottom: 12px;
+        }
+        .section-heading {
+          font-size: 28px;
+          font-weight: 700;
+          color: #f1f5f9;
+          margin-bottom: 40px;
+        }
+
+        /* Features */
+        .features-section {
+          margin-bottom: 80px;
+        }
+        .features-grid {
+          display: grid;
+          grid-template-columns: repeat(2, 1fr);
+          gap: 20px;
+        }
+        .feature-card {
+          background: rgba(255, 255, 255, 0.04);
+          border: 1px solid rgba(255, 255, 255, 0.08);
+          border-radius: 14px;
+          padding: 28px;
+          transition: border-color 0.2s, background 0.2s;
+        }
+        .feature-card:hover {
+          border-color: rgba(99, 102, 241, 0.4);
+          background: rgba(99, 102, 241, 0.05);
+        }
+        .feature-header {
+          display: flex;
+          align-items: center;
+          gap: 14px;
+          margin-bottom: 12px;
+        }
+        .feature-icon {
+          font-size: 28px;
+        }
+        .feature-title {
+          font-size: 17px;
+          font-weight: 700;
+          color: #f1f5f9;
+        }
+        .feature-desc {
+          font-size: 14px;
+          color: #94a3b8;
+          line-height: 1.65;
+        }
+        .status-badge {
+          display: inline-block;
+          font-size: 11px;
+          font-weight: 600;
+          padding: 3px 10px;
+          border-radius: 999px;
+          margin-top: 14px;
+        }
+        .status-done {
+          background: rgba(16, 185, 129, 0.15);
+          color: #6ee7b7;
+          border: 1px solid rgba(16, 185, 129, 0.3);
+        }
+        .status-planned {
+          background: rgba(99, 102, 241, 0.12);
+          color: #a5b4fc;
+          border: 1px solid rgba(99, 102, 241, 0.25);
+        }
+
+        /* Tech stack */
+        .tech-section {
+          margin-bottom: 80px;
+        }
+        .tech-grid {
           display: grid;
           grid-template-columns: repeat(3, 1fr);
-          gap: 20px;
+          gap: 14px;
         }
-        
-        .chat-room {
-          background: white;
-          border-radius: 12px;
-          box-shadow: 0 10px 40px rgba(0,0,0,0.1);
-          display: flex;
-          flex-direction: column;
-          height: 200px;
-          overflow: hidden;
+        .tech-item {
+          background: rgba(255, 255, 255, 0.04);
+          border: 1px solid rgba(255, 255, 255, 0.08);
+          border-radius: 10px;
+          padding: 16px 20px;
         }
-        
-        .chat-room.main {
-          height: 400px;
-        }
-        
-        .chat-room-header {
-          padding: 12px 16px;
-          background: #f9fafb;
-          color: #1f2937;
-          font-weight: 600;
+        .tech-name {
           font-size: 14px;
-          border-bottom: 1px solid #e5e7eb;
+          font-weight: 700;
+          color: #e2e8f0;
+          margin-bottom: 4px;
+        }
+        .tech-desc {
+          font-size: 12px;
+          color: #64748b;
+        }
+
+        /* Dev links */
+        .dev-section {
+          border-top: 1px solid rgba(255, 255, 255, 0.07);
+          padding-top: 40px;
+        }
+        .dev-links {
           display: flex;
-          align-items: center;
-          justify-content: space-between;
-          gap: 12px;
-        }
-        
-        .chat-room-header.main {
-          background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
-          color: white;
-          font-size: 18px;
-        }
-
-        .connection-status {
-          font-size: 13px;
-          font-weight: 600;
-          opacity: 0.95;
-          white-space: nowrap;
-        }
-
-        .connection-right {
-          display: inline-flex;
-          align-items: center;
-          gap: 10px;
-          min-width: 0;
-        }
-
-        .connected-room-title {
-          font-size: 13px;
-          font-weight: 600;
-          opacity: 0.95;
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          max-width: 320px;
-        }
-
-        .connected-room-title.muted {
-          opacity: 0.8;
-          font-weight: 500;
-        }
-        
-        .chat-room-messages {
-          flex: 1;
-          padding: 12px;
-          overflow-y: auto;
-          display: flex;
-          flex-direction: column;
-          gap: 8px;
-          font-size: 11px;
-          color: #1f2937;
-        }
-        
-        .chat-room.main .chat-room-messages {
-          font-size: 14px;
-        }
-        
-        .chat-room-empty {
-          color: #9ca3af;
-          font-style: italic;
-          font-size: 10px;
-          text-align: center;
-          margin-top: 20px;
-        }
-        
-        .chat-room.main .chat-room-empty {
-          font-size: 13px;
-        }
-        
-        .chat-message {
-          padding: 8px 12px;
-          background: #f9fafb;
-          border-radius: 6px;
-          word-break: break-word;
-        }
-        
-        .chat-message-content {
-          display: flex;
-          align-items: center;
-          gap: 8px;
+          gap: 14px;
           flex-wrap: wrap;
-          font-size: 11px;
         }
-        
-        .chat-room.main .chat-message-content {
-          font-size: 13px;
-        }
-        
-        .chat-message-nickname {
-          font-weight: 600;
-          color: #667eea;
-        }
-        
-        .chat-message-separator {
-          color: #9ca3af;
-        }
-        
-        .chat-message-text {
-          flex: 1;
-        }
-        
-        .chat-message-time {
-          font-size: 10px;
-          color: #9ca3af;
-        }
-        
-        .chat-room.main .chat-message-time {
-          font-size: 10px;
-        }
-        
-        .chat-room-input {
-          border-top: 1px solid #e5e7eb;
-          padding: 12px;
-          display: flex;
-          gap: 8px;
-        }
-        
-        .chat-input {
-          flex: 1;
-          padding: 10px;
-          border: 1px solid #d1d5db;
-          border-radius: 6px;
-          font-size: 14px;
-          outline: none;
-          transition: border-color 0.2s;
-        }
-        
-        .chat-input:focus {
-          border-color: #667eea;
-          box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
-        }
-        
-        .chat-send-btn {
-          padding: 10px 20px;
-          background: #6c757d;
-          color: white;
-          border: none;
-          border-radius: 6px;
-          font-size: 14px;
-          font-weight: 600;
-          cursor: pointer;
-          transition: all 0.2s;
-        }
-        
-        .chat-send-btn.main {
-          background: #6366f1;
-        }
-        
-        .chat-send-btn:hover {
-          transform: translateY(-2px);
-          box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-        }
-        
-        .chat-send-btn.main:hover {
-          background: #4f46e5;
-        }
-        
-        .chat-send-btn:not(.main):hover {
-          background: #5a6268;
-        }
-        
-        .modal-overlay {
-          position: fixed;
-          top: 0;
-          left: 0;
-          right: 0;
-          bottom: 0;
-          background: rgba(0, 0, 0, 0.5);
+        .dev-link {
           display: flex;
           align-items: center;
-          justify-content: center;
-          z-index: 1000;
-        }
-        
-        .modal-content {
-          background: white;
-          border-radius: 12px;
-          padding: 30px;
-          width: 90%;
-          max-width: 500px;
-          box-shadow: 0 10px 40px rgba(0,0,0,0.1);
-        }
-        
-        .modal-title {
-          font-size: 24px;
-          font-weight: 600;
-          margin-bottom: 20px;
-          color: #1f2937;
-        }
-        
-        .modal-form-group {
-          margin-bottom: 20px;
-        }
-        
-        .modal-label {
-          display: block;
-          margin-bottom: 8px;
-          font-size: 14px;
-          font-weight: 600;
-          color: #374151;
-        }
-        
-        .modal-input {
-          width: 100%;
-          padding: 12px;
-          border: 1px solid #d1d5db;
-          border-radius: 6px;
-          font-size: 14px;
-          outline: none;
-          transition: border-color 0.2s;
-        }
-        
-        .modal-input:focus {
-          border-color: #667eea;
-          box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
-        }
-        
-        .modal-actions {
-          display: flex;
           gap: 10px;
-          justify-content: flex-end;
-        }
-        
-        .btn-cancel {
-          padding: 10px 20px;
-          background: #6c757d;
-          color: white;
-          border: none;
-          border-radius: 6px;
+          background: rgba(255, 255, 255, 0.04);
+          border: 1px solid rgba(255, 255, 255, 0.08);
+          border-radius: 10px;
+          padding: 14px 20px;
           font-size: 14px;
           font-weight: 600;
-          cursor: pointer;
-          transition: all 0.2s;
+          color: #94a3b8;
+          transition: border-color 0.2s, color 0.2s;
         }
-        
-        .btn-cancel:hover {
-          transform: translateY(-2px);
-          box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-          background: #5a6268;
+        .dev-link:hover {
+          border-color: rgba(99, 102, 241, 0.5);
+          color: #a5b4fc;
         }
-        
-        .btn-save {
-          padding: 10px 20px;
-          background: #10b981;
-          color: white;
-          border: none;
-          border-radius: 6px;
-          font-size: 14px;
-          font-weight: 600;
-          cursor: pointer;
-          transition: all 0.2s;
-        }
-        
-        .btn-save:hover:not(:disabled) {
-          transform: translateY(-2px);
-          box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-          background: #059669;
-        }
-        
-        .btn-save:disabled,
-        .btn-cancel:disabled {
-          opacity: 0.6;
-          cursor: not-allowed;
-          transform: none;
-        }
-        
-        .modal-input:disabled {
-          background-color: #f3f4f6;
-          cursor: not-allowed;
-        }
-        
-        @media (max-width: 768px) {
-          .main-content {
-            flex-direction: column;
-          }
-          
-          .main-chat-wrapper {
-            width: 100%;
-          }
-          
-          .sub-chat-grid {
-            grid-template-columns: 1fr;
-          }
+
+        @media (max-width: 640px) {
+          .hero h1 { font-size: 34px; }
+          .features-grid { grid-template-columns: 1fr; }
+          .tech-grid { grid-template-columns: repeat(2, 1fr); }
         }
       `}</style>
 
-      <div className="main-container">
-        <div className="page-header">
-          <h1>🚀 Live Platform Lab - 채팅방</h1>
-        </div>
-
-        <div className="main-content">
-          <div className="main-chat-wrapper">
-            <ChatRoom
-              title={rooms.find((r) => r.roomId === selectedRoomId)?.title || ''}
-              isMain={true}
-              nickname="메인 사용자"
-              connectionStatusText={
-                connections['main']?.connected ? '연결됨' : '연결 안 됨'
-              }
-              connectedRoomTitle={
-                connections['main']?.connectedRoomId
-                  ? rooms.find((r) => r.roomId === connections['main']?.connectedRoomId)?.title ||
-                    connections['main']?.connectedRoomId ||
-                    undefined
-                  : undefined
-              }
-              externalMessages={mainMessages}
-              onSendMessage={(text) =>
-                sendChatMessage(text, {
-                  userId: 'main',
-                  username: 'main@example.com',
-                  sender: '메인 사용자',
-                })
-              }
-              sendDisabled={!connections['main']?.connected}
-            />
+      <div className="container">
+        {/* Hero */}
+        <section className="hero">
+          <div className="hero-badge">AI × Live Commerce</div>
+          <h1>Live Platform Lab</h1>
+          <p>
+            상품 PDF 임베딩부터 실시간 AI 답변, 호스트 인사이트까지 —
+            라이브 커머스를 위한 AI 플랫폼 실험실입니다.
+          </p>
+          <div className="hero-actions">
+            <a
+              href="https://github.com/kjuiop/live-platform-lab"
+              target="_blank"
+              rel="noreferrer"
+              className="btn-primary"
+            >
+              GitHub
+            </a>
           </div>
+        </section>
 
-          <div className="control-panel">
-            <div className="control-panel-title">채팅방 선택</div>
-            <div className="control-panel-controls">
-              <select
-                value={selectedRoomId}
-                onChange={(e) => setSelectedRoomId(e.target.value)}
-                className="control-select"
-                disabled={isRoomsLoading || rooms.length === 0}
-              >
-                {isRoomsLoading ? (
-                  <option value="">불러오는 중...</option>
-                ) : rooms.length === 0 ? (
-                  <option value="">채팅방이 없습니다</option>
-                ) : (
-                  rooms.map((room) => (
-                    <option key={room.roomId} value={room.roomId}>
-                      {room.title}
-                    </option>
-                  ))
-                )}
-              </select>
-              <button onClick={handleCreateChatRoom} className="btn-create">
-                생성
-              </button>
-              <button
-                onClick={handleConnectChatRoom}
-                className="btn-connect"
-                disabled={isRoomsLoading || rooms.length === 0 || !selectedRoomId || !areWsScriptsReady}
-                title={
-                  !areWsScriptsReady
-                    ? 'WebSocket 라이브러리 로딩 중...'
-                    : selectedRoomId
-                      ? '선택한 채팅방에 연결(테스트: 유저별로 분리 커넥션)'
-                      : '채팅방을 먼저 선택하세요'
-                }
-              >
-                {demoUsers.every((u) => connections[u.key]?.connected && connections[u.key]?.connectedRoomId === selectedRoomId)
-                  ? '연결 끊기'
-                  : '연결'}
-              </button>
-            </div>
-            {roomsError && (
-              <div style={{ marginTop: 8, fontSize: 13, color: '#ef4444' }}>
-                {roomsError}
-              </div>
-            )}
-            {/* 연결/에러 표시는 메인 채팅창 헤더로 이동 */}
-          </div>
-        </div>
-
-        <div className="sub-chat-grid">
-          {demoUsers
-            .filter((u) => !u.isMain)
-            .map((u) => (
-            <ChatRoom
-              key={u.userId}
-              title={rooms.find((r) => r.roomId === selectedRoomId)?.title || ''}
-              nickname={u.sender}
-              connectionStatusText={
-                connections[u.key]?.connected ? '연결됨' : '연결 안 됨'
-              }
-              connectedRoomTitle={
-                connections[u.key]?.connectedRoomId
-                  ? rooms.find((r) => r.roomId === connections[u.key]?.connectedRoomId)?.title ||
-                    connections[u.key]?.connectedRoomId ||
-                    undefined
-                  : undefined
-              }
-              externalMessages={mainMessages}
-              onSendMessage={(text) => sendChatMessage(text, u)}
-              sendDisabled={!connections[u.key]?.connected}
-            />
-          ))}
-        </div>
-      </div>
-
-      {isModalOpen && (
-        <div className="modal-overlay" onClick={handleCloseModal}>
-          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-            <h2 className="modal-title">채팅방 생성</h2>
-            <div className="modal-form-group">
-              <label className="modal-label">채팅방 제목</label>
-              <input
-                type="text"
-                value={newChatRoomTitle}
-                onChange={(e) => {
-                  setNewChatRoomTitle(e.target.value);
-                  setError(null); // 입력 시 에러 초기화
-                }}
-                onKeyPress={handleKeyPress}
-                placeholder="채팅방 제목을 입력하세요"
-                className="modal-input"
-                autoFocus
-                disabled={isLoading}
-              />
-              {error && (
-                <div className="modal-error" style={{ 
-                  color: '#ef4444', 
-                  fontSize: '14px', 
-                  marginTop: '8px' 
-                }}>
-                  {error}
+        {/* Features */}
+        <section className="features-section">
+          <div className="section-title">Features</div>
+          <div className="section-heading">주요 기능</div>
+          <div className="features-grid">
+            {features.map((f) => (
+              <div key={f.title} className="feature-card">
+                <div className="feature-header">
+                  <span className="feature-icon">{f.icon}</span>
+                  <span className="feature-title">{f.title}</span>
                 </div>
-              )}
-            </div>
-            <div className="modal-actions">
-              <button 
-                onClick={handleCloseModal} 
-                className="btn-cancel"
-                disabled={isLoading}
-              >
-                취소
-              </button>
-              <button 
-                onClick={handleSaveChatRoom} 
-                className="btn-save"
-                disabled={isLoading || !newChatRoomTitle.trim()}
-              >
-                {isLoading ? '생성 중...' : '저장'}
-              </button>
-            </div>
+                <p className="feature-desc">{f.description}</p>
+                <span className={`status-badge ${f.status === 'done' ? 'status-done' : 'status-planned'}`}>
+                  {f.status === 'done' ? '구현 완료' : '개발 예정'}
+                </span>
+              </div>
+            ))}
           </div>
-        </div>
-      )}
+        </section>
+
+        {/* Tech Stack */}
+        <section className="tech-section">
+          <div className="section-title">Stack</div>
+          <div className="section-heading">기술 스택</div>
+          <div className="tech-grid">
+            {techStack.map((t) => (
+              <div key={t.name} className="tech-item">
+                <div className="tech-name">{t.name}</div>
+                <div className="tech-desc">{t.desc}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Dev Links */}
+        <section className="dev-section">
+          <div className="section-title">Dev</div>
+          <div className="section-heading">개발 도구</div>
+          <div className="dev-links">
+            <Link href="/chat" className="dev-link">
+              💬 채팅방 데모
+            </Link>
+            <Link href="/stomp-test" className="dev-link">
+              🔌 STOMP 채팅 테스트
+            </Link>
+          </div>
+        </section>
+      </div>
     </>
   );
 }

--- a/web-client/pages/index.tsx
+++ b/web-client/pages/index.tsx
@@ -112,6 +112,7 @@ export default function Home() {
           font-size: 15px;
           font-weight: 600;
           transition: opacity 0.2s, transform 0.2s;
+          margin-top: 8px;
         }
         .btn-primary:hover {
           opacity: 0.9;

--- a/web-client/pages/index.tsx
+++ b/web-client/pages/index.tsx
@@ -277,11 +277,14 @@ export default function Home() {
             라이브 커머스를 위한 AI 플랫폼 실험실입니다.
           </p>
           <div className="hero-actions">
+            <Link href="/broadcasts" className="btn-primary">
+              📡 방송 목록 보기
+            </Link>
             <a
               href="https://github.com/kjuiop/live-platform-lab"
               target="_blank"
               rel="noreferrer"
-              className="btn-primary"
+              className="btn-secondary"
             >
               GitHub
             </a>

--- a/web-client/pages/products.tsx
+++ b/web-client/pages/products.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+interface Product {
+  id: string;
+  name: string;
+  category: string;
+  price: number;
+  description: string;
+  embeddingStatus: 'none' | 'pending' | 'done';
+}
+
+const MOCK_PRODUCTS: Product[] = [
+  { id: 'P001', name: '워터프루프 립스틱', category: '뷰티', price: 25000, description: '24시간 지속되는 방수 립스틱. 선명한 발색과 촉촉한 보습력을 동시에.', embeddingStatus: 'done' },
+  { id: 'P002', name: '비타민C 세럼', category: '스킨케어', price: 48000, description: '고농도 비타민C 15% 함유. 미백과 탄력 개선에 효과적입니다.', embeddingStatus: 'done' },
+  { id: 'P003', name: '쿠션 파운데이션', category: '뷰티', price: 35000, description: 'SPF50+ PA++++ 자외선 차단. 촉촉한 피부 표현에 최적화된 쿠션.', embeddingStatus: 'none' },
+];
+
+
+export default function Products() {
+  const router = useRouter();
+  const [products] = useState<Product[]>(MOCK_PRODUCTS);
+
+  return (
+    <>
+      <Head><title>상품 관리 — Live Platform Lab</title></Head>
+      <style jsx global>{`* { margin: 0; padding: 0; box-sizing: border-box; } body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f172a; color: #e2e8f0; min-height: 100vh; } a { text-decoration: none; color: inherit; }`}</style>
+      <style jsx>{`
+        .container { max-width: 1100px; margin: 0 auto; padding: 40px 24px; }
+        .nav { display: flex; align-items: center; gap: 8px; margin-bottom: 40px; font-size: 14px; color: #64748b; }
+        .nav a:hover { color: #a5b4fc; }
+        .nav-sep { color: #334155; }
+        .header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 32px; }
+        .title { font-size: 28px; font-weight: 700; color: #f1f5f9; }
+        .btn-add { padding: 10px 22px; background: linear-gradient(135deg, #6366f1, #8b5cf6); color: white; border: none; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; transition: opacity 0.2s, transform 0.2s; }
+        .btn-add:hover { opacity: 0.9; transform: translateY(-1px); }
+        .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+        .card { background: #1e293b; border: 1px solid rgba(255,255,255,0.1); border-radius: 16px; padding: 24px; transition: border-color 0.18s, box-shadow 0.18s; cursor: pointer; }
+        .card:hover { border-color: rgba(99,102,241,0.4); box-shadow: 0 4px 24px rgba(0,0,0,0.3); }
+        .card-top { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; margin-bottom: 10px; }
+        .card-name { font-size: 17px; font-weight: 700; color: #f1f5f9; line-height: 1.3; }
+        .badge-category { font-size: 11px; font-weight: 700; padding: 3px 10px; border-radius: 999px; white-space: nowrap; flex-shrink: 0; background: rgba(99,102,241,0.15); color: #a5b4fc; border: 1px solid rgba(99,102,241,0.25); }
+        .card-desc { font-size: 13px; color: #64748b; line-height: 1.65; margin-bottom: 20px; }
+        .card-divider { height: 1px; background: rgba(255,255,255,0.07); margin-bottom: 16px; }
+        .card-bottom { display: flex; align-items: center; justify-content: space-between; }
+        .price { font-size: 18px; font-weight: 800; color: #f1f5f9; }
+        .badge-embed { font-size: 11px; font-weight: 700; padding: 4px 11px; border-radius: 999px; }
+        .embed-done { background: rgba(16,185,129,0.12); color: #6ee7b7; border: 1px solid rgba(16,185,129,0.25); }
+        .embed-pending { background: rgba(251,191,36,0.12); color: #fcd34d; border: 1px solid rgba(251,191,36,0.25); }
+        .embed-none { background: rgba(100,116,139,0.12); color: #94a3b8; border: 1px solid rgba(100,116,139,0.25); }
+        @media (max-width: 768px) { .grid { grid-template-columns: 1fr; } }
+      `}</style>
+
+      <div className="container">
+        <nav className="nav">
+          <Link href="/">홈</Link>
+          <span className="nav-sep">/</span>
+          <span>상품 관리</span>
+        </nav>
+
+        <div className="header">
+          <h1 className="title">상품 관리</h1>
+          <button className="btn-add" onClick={() => router.push('/products/new')}>+ 상품 등록</button>
+        </div>
+
+        <div className="grid">
+          {products.map((p) => (
+            <div key={p.id} className="card" onClick={() => router.push(`/products/${p.id}`)}>
+              <div className="card-top">
+                <span className="card-name">{p.name}</span>
+                <span className="badge-category">{p.category}</span>
+              </div>
+              <p className="card-desc">{p.description}</p>
+              <div className="card-divider" />
+              <div className="card-bottom">
+                <span className="price">{p.price.toLocaleString()}원</span>
+                <span className={`badge-embed ${
+                  p.embeddingStatus === 'done' ? 'embed-done'
+                  : p.embeddingStatus === 'pending' ? 'embed-pending'
+                  : 'embed-none'
+                }`}>
+                  {p.embeddingStatus === 'done' ? '임베딩 완료'
+                    : p.embeddingStatus === 'pending' ? '임베딩 중...'
+                    : 'AI 미등록'}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+    </>
+  );
+}

--- a/web-client/pages/products/[id].tsx
+++ b/web-client/pages/products/[id].tsx
@@ -1,0 +1,491 @@
+import React, { useState, useRef, useEffect } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+type EmbeddingStatus = 'none' | 'pending' | 'done';
+
+interface Product {
+  id: string;
+  name: string;
+  category: string;
+  price: number;
+  description: string;
+  embeddingStatus: EmbeddingStatus;
+  ingredients?: string;
+  usage?: string;
+  manufacturer?: string;
+}
+
+interface Document {
+  id: string;
+  name: string;
+  size: string;
+  uploadedAt: string;
+  status: EmbeddingStatus;
+  chunkCount?: number;
+}
+
+interface QnAItem {
+  id: number;
+  question: string;
+  answer: string;
+  isLoading?: boolean;
+}
+
+interface RelatedBroadcast {
+  id: string;
+  title: string;
+  status: 'scheduled' | 'live' | 'ended';
+  viewerCount?: number;
+}
+
+const MOCK_PRODUCTS: Product[] = [
+  {
+    id: 'P001',
+    name: '워터프루프 립스틱',
+    category: '뷰티',
+    price: 25000,
+    description: '24시간 지속되는 방수 립스틱. 선명한 발색과 촉촉한 보습력을 동시에.',
+    embeddingStatus: 'done',
+    ingredients: '정제수, 디메치콘, 이소도데케인, 트리메틸실록시실리케이트, 폴리에틸렌, 세레신, 카르나우바왁스, 향료',
+    usage: '입술에 직접 바르거나 브러시를 이용하여 원하는 만큼 발라주세요. 리터치 시 티슈로 가볍게 정리 후 재도포합니다.',
+    manufacturer: '뷰티코리아',
+  },
+  {
+    id: 'P002',
+    name: '비타민C 세럼',
+    category: '스킨케어',
+    price: 48000,
+    description: '고농도 비타민C 15% 함유. 미백과 탄력 개선에 효과적입니다.',
+    embeddingStatus: 'done',
+    ingredients: '아스코르빅애씨드 15%, 정제수, 글리세린, 판테놀, 나이아신아마이드, 히알루론산',
+    usage: '세안 후 토너 사용 후, 세럼 2~3방울을 얼굴 전체에 고르게 펴 바르세요. 아침·저녁 사용을 권장합니다.',
+    manufacturer: '스킨랩',
+  },
+  {
+    id: 'P003',
+    name: '쿠션 파운데이션',
+    category: '뷰티',
+    price: 35000,
+    description: 'SPF50+ PA++++ 자외선 차단. 촉촉한 피부 표현에 최적화된 쿠션.',
+    embeddingStatus: 'none',
+    ingredients: '정제수, 사이클로펜타실록세인, 부틸렌글라이콜, 글리세린, 나이아신아마이드',
+    usage: '퍼프에 제품을 적당량 묻혀 피부 안쪽에서 바깥쪽으로 톡톡 두드리듯 발라주세요.',
+    manufacturer: '뷰티코리아',
+  },
+];
+
+const MOCK_DOCUMENTS: Record<string, Document[]> = {
+  P001: [
+    { id: 'D001', name: '워터프루프_립스틱_성분표.pdf', size: '1.2 MB', uploadedAt: '2026-04-10', status: 'done', chunkCount: 24 },
+    { id: 'D002', name: '립스틱_사용설명서.pdf', size: '0.8 MB', uploadedAt: '2026-04-10', status: 'done', chunkCount: 15 },
+  ],
+  P002: [
+    { id: 'D003', name: '비타민C_세럼_성분분석.pdf', size: '2.1 MB', uploadedAt: '2026-04-08', status: 'done', chunkCount: 38 },
+  ],
+  P003: [],
+};
+
+const MOCK_BROADCASTS: Record<string, RelatedBroadcast[]> = {
+  P001: [
+    { id: 'B001', title: '봄맞이 뷰티 라이브', status: 'live', viewerCount: 1243 },
+  ],
+  P002: [
+    { id: 'B002', title: '스킨케어 집중 케어', status: 'scheduled' },
+  ],
+  P003: [
+    { id: 'B003', title: '파운데이션 비교 테스트', status: 'ended', viewerCount: 3892 },
+  ],
+};
+
+const MOCK_AI_ANSWERS: Record<string, string> = {
+  '성분': '이 제품의 주요 성분으로는 보습 효과가 뛰어난 글리세린과 히알루론산이 포함되어 있으며, 피부과 테스트를 완료한 저자극 포뮬러입니다.',
+  '지속력': '워터프루프 포뮬러 적용으로 최대 12시간 지속됩니다. 물이나 땀에도 번짐 없이 유지됩니다.',
+  '사용법': '세안 후 스킨케어 마지막 단계에 사용해주세요. 소량을 덜어 얼굴 전체에 고르게 펴 바르면 됩니다.',
+  '가격': `정상가 기준이며, 방송 라이브 중 특가 혜택이 적용될 수 있습니다. 상세 가격은 방송을 참고해주세요.`,
+  '부작용': '민감성 피부의 경우 사용 전 팔 안쪽에 패치 테스트를 권장합니다. 이상이 있을 경우 즉시 사용을 중단하고 전문가와 상담하세요.',
+  default: '해당 상품의 등록된 정보를 기반으로 답변드립니다. 더 구체적인 질문을 입력해주시면 더 정확한 답변을 제공할 수 있습니다.',
+};
+
+const categoryColors: Record<string, string> = {
+  '뷰티': '#f472b6',
+  '스킨케어': '#60a5fa',
+  '패션': '#34d399',
+  '식품': '#fbbf24',
+};
+
+const broadcastStatusLabel = { scheduled: '예정', live: '라이브 중', ended: '종료' };
+const broadcastStatusClass = { scheduled: 'bs-scheduled', live: 'bs-live', ended: 'bs-ended' };
+
+export default function ProductDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+
+  const product = MOCK_PRODUCTS.find((p) => p.id === id) ?? null;
+  const documents = MOCK_DOCUMENTS[id as string] ?? [];
+  const relatedBroadcasts = MOCK_BROADCASTS[id as string] ?? [];
+
+  const [qnaList, setQnaList] = useState<QnAItem[]>([]);
+  const [aiInput, setAiInput] = useState('');
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [mockDocs, setMockDocs] = useState<Document[]>(documents);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const qnaBottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    qnaBottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [qnaList]);
+
+  // 문서 목록은 id가 바뀔 때 동기화
+  useEffect(() => {
+    setMockDocs(MOCK_DOCUMENTS[id as string] ?? []);
+  }, [id]);
+
+  const askAI = () => {
+    const q = aiInput.trim();
+    if (!q) return;
+    setAiInput('');
+    const newItem: QnAItem = { id: Date.now(), question: q, answer: '', isLoading: true };
+    setQnaList((prev) => [...prev, newItem]);
+    const keyword = Object.keys(MOCK_AI_ANSWERS).find((k) => k !== 'default' && q.includes(k));
+    const answer = MOCK_AI_ANSWERS[keyword ?? 'default'];
+    setTimeout(() => {
+      setQnaList((prev) => prev.map((item) => item.id === newItem.id ? { ...item, answer, isLoading: false } : item));
+    }, 1200);
+  };
+
+  const handleFileDrop = (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    Array.from(files).forEach((file) => {
+      const newDoc: Document = {
+        id: `D${Date.now()}`,
+        name: file.name,
+        size: `${(file.size / 1024 / 1024).toFixed(1)} MB`,
+        uploadedAt: new Date().toISOString().slice(0, 10),
+        status: 'pending',
+      };
+      setMockDocs((prev) => [...prev, newDoc]);
+      // 임베딩 완료 시뮬레이션
+      setTimeout(() => {
+        setMockDocs((prev) =>
+          prev.map((d) => d.id === newDoc.id ? { ...d, status: 'done', chunkCount: Math.floor(Math.random() * 30) + 10 } : d)
+        );
+      }, 2000);
+    });
+  };
+
+  if (!id) return null;
+
+  if (!product) {
+    return (
+      <>
+        <Head><title>상품을 찾을 수 없음</title></Head>
+        <style jsx global>{`* { margin:0;padding:0;box-sizing:border-box; } body { font-family:-apple-system,sans-serif; background:#0f172a; color:#e2e8f0; min-height:100vh; } a { text-decoration:none;color:inherit; }`}</style>
+        <div style={{ maxWidth: 600, margin: '0 auto', padding: '80px 24px', textAlign: 'center' }}>
+          <div style={{ fontSize: 48, marginBottom: 20 }}>📦</div>
+          <h1 style={{ fontSize: 24, fontWeight: 700, color: '#f1f5f9', marginBottom: 12 }}>상품을 찾을 수 없습니다</h1>
+          <p style={{ color: '#64748b', marginBottom: 32 }}>요청하신 상품이 존재하지 않거나 삭제되었습니다.</p>
+          <Link href="/products" style={{ padding: '10px 24px', background: 'linear-gradient(135deg,#6366f1,#8b5cf6)', color: 'white', borderRadius: 8, fontSize: 14, fontWeight: 600 }}>
+            목록으로 돌아가기
+          </Link>
+        </div>
+      </>
+    );
+  }
+
+  const catColor = categoryColors[product.category] ?? '#a5b4fc';
+  const totalChunks = mockDocs.filter((d) => d.status === 'done').reduce((sum, d) => sum + (d.chunkCount ?? 0), 0);
+
+  return (
+    <>
+      <Head><title>{product.name} — Live Platform Lab</title></Head>
+      <style jsx global>{`* { margin:0;padding:0;box-sizing:border-box; } body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:#0f172a; color:#e2e8f0; min-height:100vh; } a { text-decoration:none;color:inherit; }`}</style>
+      <style jsx>{`
+        .container { max-width: 1100px; margin: 0 auto; padding: 40px 24px; }
+        .nav { display: flex; align-items: center; gap: 8px; margin-bottom: 40px; font-size: 13px; color: #64748b; }
+        .nav a:hover { color: #a5b4fc; }
+        .nav-sep { color: #334155; }
+
+        .layout { display: grid; grid-template-columns: 1fr 360px; gap: 24px; align-items: start; }
+
+        /* 좌측 */
+        .left { display: flex; flex-direction: column; gap: 20px; }
+
+        .info-card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; padding: 28px; }
+        .info-top { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 8px; }
+        .info-name { font-size: 26px; font-weight: 800; color: #f1f5f9; }
+        .embed-badge { font-size: 11px; font-weight: 700; padding: 4px 12px; border-radius: 999px; white-space: nowrap; flex-shrink: 0; margin-top: 4px; }
+        .embed-done { background: rgba(16,185,129,0.12); color: #6ee7b7; border: 1px solid rgba(16,185,129,0.25); }
+        .embed-pending { background: rgba(251,191,36,0.12); color: #fcd34d; border: 1px solid rgba(251,191,36,0.25); }
+        .embed-none { background: rgba(100,116,139,0.12); color: #94a3b8; border: 1px solid rgba(100,116,139,0.25); }
+        .info-meta { display: flex; align-items: center; gap: 10px; margin-bottom: 20px; }
+        .cat-badge { font-size: 12px; font-weight: 700; padding: 3px 12px; border-radius: 999px; }
+        .info-price { font-size: 22px; font-weight: 800; color: #f1f5f9; }
+        .info-desc { font-size: 14px; color: #94a3b8; line-height: 1.75; margin-bottom: 24px; }
+        .info-details { display: flex; flex-direction: column; gap: 14px; border-top: 1px solid rgba(255,255,255,0.07); padding-top: 20px; }
+        .detail-row { display: flex; gap: 12px; }
+        .detail-label { font-size: 12px; font-weight: 700; color: #64748b; width: 56px; flex-shrink: 0; padding-top: 1px; }
+        .detail-val { font-size: 13px; color: #94a3b8; line-height: 1.65; }
+
+        /* 문서 */
+        .section-card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; padding: 24px; }
+        .section-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
+        .section-title { font-size: 15px; font-weight: 700; color: #f1f5f9; }
+        .section-sub { font-size: 11px; color: #64748b; margin-top: 2px; }
+        .chunk-badge { font-size: 11px; font-weight: 700; padding: 3px 10px; border-radius: 999px; background: rgba(16,185,129,0.1); color: #6ee7b7; border: 1px solid rgba(16,185,129,0.2); }
+
+        .drop-zone { border: 1.5px dashed rgba(99,102,241,0.3); border-radius: 10px; padding: 20px; text-align: center; cursor: pointer; transition: border-color 0.2s, background 0.2s; margin-bottom: 14px; }
+        .drop-zone:hover, .drop-zone.over { border-color: rgba(99,102,241,0.6); background: rgba(99,102,241,0.05); }
+        .drop-zone-text { font-size: 13px; color: #475569; }
+        .drop-zone-sub { font-size: 11px; color: #334155; margin-top: 4px; }
+
+        .doc-list { display: flex; flex-direction: column; gap: 8px; }
+        .doc-item { display: flex; align-items: center; gap: 12px; padding: 10px 14px; background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.06); border-radius: 8px; }
+        .doc-icon { font-size: 18px; flex-shrink: 0; }
+        .doc-info { flex: 1; min-width: 0; }
+        .doc-name { font-size: 13px; font-weight: 600; color: #e2e8f0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .doc-meta { font-size: 11px; color: #475569; margin-top: 2px; }
+        .doc-status { flex-shrink: 0; }
+        .doc-badge { font-size: 10px; font-weight: 700; padding: 2px 8px; border-radius: 999px; }
+        .doc-done { background: rgba(16,185,129,0.12); color: #6ee7b7; border: 1px solid rgba(16,185,129,0.2); }
+        .doc-pending { background: rgba(251,191,36,0.12); color: #fcd34d; border: 1px solid rgba(251,191,36,0.2); }
+
+        .no-docs { font-size: 13px; color: #475569; text-align: center; padding: 16px 0; }
+
+        /* 우측 */
+        .right { display: flex; flex-direction: column; gap: 20px; position: sticky; top: 24px; }
+
+        /* AI Q&A */
+        .ai-card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; display: flex; flex-direction: column; max-height: 480px; overflow: hidden; }
+        .ai-header { padding: 18px 20px; border-bottom: 1px solid rgba(255,255,255,0.07); }
+        .ai-title { font-size: 15px; font-weight: 700; color: #f1f5f9; }
+        .ai-sub { font-size: 11px; color: #64748b; margin-top: 3px; }
+        .ai-body { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 14px; scrollbar-width: thin; scrollbar-color: rgba(255,255,255,0.1) transparent; }
+        .ai-body::-webkit-scrollbar { width: 4px; }
+        .ai-body::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 2px; }
+        .ai-empty { color: #475569; font-size: 13px; text-align: center; padding: 24px 0; line-height: 1.7; }
+        .qna-item { display: flex; flex-direction: column; gap: 8px; padding: 12px; background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.06); border-radius: 10px; }
+        .qna-row { display: flex; align-items: flex-start; gap: 8px; }
+        .qna-badge { font-size: 10px; font-weight: 700; padding: 2px 7px; border-radius: 999px; flex-shrink: 0; margin-top: 1px; }
+        .qna-badge.q { background: rgba(99,102,241,0.2); color: #a5b4fc; border: 1px solid rgba(99,102,241,0.3); }
+        .qna-badge.a { background: rgba(16,185,129,0.15); color: #6ee7b7; border: 1px solid rgba(16,185,129,0.25); }
+        .qna-text { font-size: 13px; color: #cbd5e1; line-height: 1.6; }
+        .qna-text.answer { color: #94a3b8; }
+        .qna-loading { font-size: 13px; color: #6ee7b7; }
+        .dots::after { content: '...'; animation: dotanim 1.2s steps(4, end) infinite; }
+        @keyframes dotanim { 0%,100% { content: ''; } 25% { content: '.'; } 50% { content: '..'; } 75% { content: '...'; } }
+        .ai-input-row { padding: 12px 16px; border-top: 1px solid rgba(255,255,255,0.07); display: flex; gap: 8px; }
+        .ai-input { flex: 1; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; padding: 9px 12px; font-size: 13px; color: #f1f5f9; outline: none; }
+        .ai-input:focus { border-color: #6366f1; }
+        .ai-send { padding: 9px 14px; background: linear-gradient(135deg, #6366f1, #8b5cf6); color: white; border: none; border-radius: 8px; font-size: 13px; font-weight: 600; cursor: pointer; white-space: nowrap; }
+        .ai-send:disabled { opacity: 0.4; cursor: not-allowed; }
+
+        /* 연결된 방송 */
+        .broadcast-list { display: flex; flex-direction: column; gap: 8px; }
+        .b-item { display: flex; align-items: center; gap: 10px; padding: 10px 14px; background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.06); border-radius: 10px; transition: border-color 0.2s; }
+        .b-item:hover { border-color: rgba(99,102,241,0.3); }
+        .b-title { flex: 1; font-size: 13px; font-weight: 600; color: #e2e8f0; }
+        .bs-live { font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 999px; background: rgba(239,68,68,0.15); color: #fca5a5; border: 1px solid rgba(239,68,68,0.3); }
+        .bs-scheduled { font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 999px; background: rgba(251,191,36,0.12); color: #fcd34d; border: 1px solid rgba(251,191,36,0.25); }
+        .bs-ended { font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 999px; background: rgba(100,116,139,0.12); color: #94a3b8; border: 1px solid rgba(100,116,139,0.2); }
+        .b-arrow { font-size: 12px; color: #334155; }
+        .no-broadcast { font-size: 13px; color: #475569; text-align: center; padding: 12px 0; }
+
+        @media (max-width: 800px) {
+          .layout { grid-template-columns: 1fr; }
+          .right { position: static; }
+        }
+      `}</style>
+
+      <div className="container">
+        <nav className="nav">
+          <Link href="/">홈</Link>
+          <span className="nav-sep">/</span>
+          <Link href="/products">상품 관리</Link>
+          <span className="nav-sep">/</span>
+          <span style={{ color: '#94a3b8' }}>{product.name}</span>
+        </nav>
+
+        <div className="layout">
+          {/* 좌측 */}
+          <div className="left">
+            {/* 상품 정보 */}
+            <div className="info-card">
+              <div className="info-top">
+                <h1 className="info-name">{product.name}</h1>
+                <span className={`embed-badge ${
+                  product.embeddingStatus === 'done' ? 'embed-done'
+                  : product.embeddingStatus === 'pending' ? 'embed-pending'
+                  : 'embed-none'
+                }`}>
+                  {product.embeddingStatus === 'done' ? '임베딩 완료'
+                    : product.embeddingStatus === 'pending' ? '임베딩 중...'
+                    : 'AI 미등록'}
+                </span>
+              </div>
+              <div className="info-meta">
+                <span
+                  className="cat-badge"
+                  style={{ background: `${catColor}18`, color: catColor, border: `1px solid ${catColor}40` }}
+                >
+                  {product.category}
+                </span>
+                <span className="info-price">{product.price.toLocaleString()}원</span>
+              </div>
+              <p className="info-desc">{product.description}</p>
+              <div className="info-details">
+                {product.ingredients && (
+                  <div className="detail-row">
+                    <span className="detail-label">주요 성분</span>
+                    <span className="detail-val">{product.ingredients}</span>
+                  </div>
+                )}
+                {product.usage && (
+                  <div className="detail-row">
+                    <span className="detail-label">사용법</span>
+                    <span className="detail-val">{product.usage}</span>
+                  </div>
+                )}
+                {product.manufacturer && (
+                  <div className="detail-row">
+                    <span className="detail-label">제조사</span>
+                    <span className="detail-val">{product.manufacturer}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* 등록 문서 */}
+            <div className="section-card">
+              <div className="section-header">
+                <div>
+                  <div className="section-title">등록된 문서</div>
+                  <div className="section-sub">업로드한 PDF가 AI Q&A의 근거 자료로 활용됩니다</div>
+                </div>
+                {totalChunks > 0 && (
+                  <span className="chunk-badge">{totalChunks} chunks</span>
+                )}
+              </div>
+
+              {/* 드래그 업로드 */}
+              <div
+                className={`drop-zone ${isDragOver ? 'over' : ''}`}
+                onClick={() => fileInputRef.current?.click()}
+                onDragOver={(e) => { e.preventDefault(); setIsDragOver(true); }}
+                onDragLeave={() => setIsDragOver(false)}
+                onDrop={(e) => { e.preventDefault(); setIsDragOver(false); handleFileDrop(e.dataTransfer.files); }}
+              >
+                <div className="drop-zone-text">PDF 파일을 드래그하거나 클릭하여 업로드</div>
+                <div className="drop-zone-sub">업로드 즉시 AI 임베딩이 시작됩니다</div>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".pdf"
+                  multiple
+                  style={{ display: 'none' }}
+                  onChange={(e) => handleFileDrop(e.target.files)}
+                />
+              </div>
+
+              {mockDocs.length === 0 ? (
+                <div className="no-docs">등록된 문서가 없습니다.</div>
+              ) : (
+                <div className="doc-list">
+                  {mockDocs.map((doc) => (
+                    <div key={doc.id} className="doc-item">
+                      <span className="doc-icon">📄</span>
+                      <div className="doc-info">
+                        <div className="doc-name">{doc.name}</div>
+                        <div className="doc-meta">
+                          {doc.size} · {doc.uploadedAt}
+                          {doc.chunkCount && ` · ${doc.chunkCount} chunks`}
+                        </div>
+                      </div>
+                      <div className="doc-status">
+                        <span className={`doc-badge ${doc.status === 'done' ? 'doc-done' : 'doc-pending'}`}>
+                          {doc.status === 'done' ? '완료' : '처리 중...'}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* 우측 */}
+          <div className="right">
+            {/* AI Q&A 테스트 */}
+            <div className="ai-card">
+              <div className="ai-header">
+                <div className="ai-title">AI Q&A 테스트</div>
+                <div className="ai-sub">등록된 문서를 바탕으로 AI가 답변합니다</div>
+              </div>
+              <div className="ai-body">
+                {qnaList.length === 0 ? (
+                  <div className="ai-empty">
+                    이 상품에 대해<br />궁금한 점을 물어보세요
+                  </div>
+                ) : (
+                  qnaList.map((item) => (
+                    <div key={item.id} className="qna-item">
+                      <div className="qna-row">
+                        <span className="qna-badge q">Q</span>
+                        <span className="qna-text">{item.question}</span>
+                      </div>
+                      <div className="qna-row">
+                        <span className="qna-badge a">AI</span>
+                        {item.isLoading ? (
+                          <span className="qna-loading">답변 생성 중<span className="dots" /></span>
+                        ) : (
+                          <span className="qna-text answer">{item.answer}</span>
+                        )}
+                      </div>
+                    </div>
+                  ))
+                )}
+                <div ref={qnaBottomRef} />
+              </div>
+              <div className="ai-input-row">
+                <input
+                  className="ai-input"
+                  value={aiInput}
+                  onChange={(e) => setAiInput(e.target.value)}
+                  onKeyPress={(e) => e.key === 'Enter' && askAI()}
+                  placeholder="예) 성분이 어떻게 되나요?"
+                />
+                <button className="ai-send" onClick={askAI} disabled={!aiInput.trim()}>질문</button>
+              </div>
+            </div>
+
+            {/* 연결된 방송 */}
+            <div className="section-card">
+              <div className="section-header">
+                <div>
+                  <div className="section-title">연결된 방송</div>
+                  <div className="section-sub">이 상품이 사용된 방송 목록</div>
+                </div>
+              </div>
+              {relatedBroadcasts.length === 0 ? (
+                <div className="no-broadcast">연결된 방송이 없습니다.</div>
+              ) : (
+                <div className="broadcast-list">
+                  {relatedBroadcasts.map((b) => (
+                    <Link key={b.id} href={`/broadcasts/${b.id}`} className="b-item">
+                      <span className="b-title">{b.title}</span>
+                      <span className={broadcastStatusClass[b.status]}>
+                        {b.status === 'live' && '● '}{broadcastStatusLabel[b.status]}
+                      </span>
+                      <span className="b-arrow">›</span>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web-client/pages/products/new.tsx
+++ b/web-client/pages/products/new.tsx
@@ -57,13 +57,6 @@ export default function ProductNew() {
     // AI 추출 시뮬레이션
     setTimeout(() => {
       const extracted = MOCK_PDF_EXTRACTED.default;
-      setForm((prev) => ({
-        ...prev,
-        ...Object.fromEntries(
-          Object.entries(extracted).filter(([, v]) => v && !prev[_ as keyof ProductForm] || prev[_ as keyof ProductForm] === '')
-            .map(([k, v]) => [k, v])
-        ),
-      }));
       // 빈 필드만 채우기
       setForm((prev) => ({
         name: prev.name || extracted.name || '',

--- a/web-client/pages/products/new.tsx
+++ b/web-client/pages/products/new.tsx
@@ -1,0 +1,330 @@
+import React, { useState, useRef } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+interface ProductForm {
+  name: string;
+  category: string;
+  price: string;
+  description: string;
+  ingredients: string;
+  usage: string;
+  manufacturer: string;
+}
+
+const EMPTY_FORM: ProductForm = {
+  name: '', category: '', price: '', description: '',
+  ingredients: '', usage: '', manufacturer: '',
+};
+
+// PDF 업로드 시 AI 추출 시뮬레이션 데이터
+const MOCK_PDF_EXTRACTED: Record<string, Partial<ProductForm>> = {
+  default: {
+    name: '모이스처라이징 선크림',
+    category: '스킨케어',
+    price: '32000',
+    description: 'SPF50+ PA++++ 자외선 차단과 동시에 피부 보습을 케어하는 멀티 기능성 선크림입니다.',
+    ingredients: '정제수, 이산화티탄, 징크옥사이드, 글리세린, 나이아신아마이드, 히알루론산나트륨, 판테놀',
+    usage: '외출 30분 전 피부 마지막 단계에 적당량을 얼굴 전체에 고르게 펴 바르세요. 2~3시간마다 덧바르는 것을 권장합니다.',
+    manufacturer: '스킨랩',
+  },
+};
+
+export default function ProductNew() {
+  const router = useRouter();
+  const [form, setForm] = useState<ProductForm>(EMPTY_FORM);
+  const [errors, setErrors] = useState<Partial<ProductForm>>({});
+  const [pdfFile, setPdfFile] = useState<{ name: string; size: string } | null>(null);
+  const [pdfState, setPdfState] = useState<'idle' | 'extracting' | 'done'>('idle');
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const set = (key: keyof ProductForm) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    setForm((prev) => ({ ...prev, [key]: e.target.value }));
+    setErrors((prev) => ({ ...prev, [key]: undefined }));
+  };
+
+  const handlePdf = (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const file = files[0];
+    if (!file.name.endsWith('.pdf')) return;
+
+    setPdfFile({ name: file.name, size: `${(file.size / 1024 / 1024).toFixed(1)} MB` });
+    setPdfState('extracting');
+
+    // AI 추출 시뮬레이션
+    setTimeout(() => {
+      const extracted = MOCK_PDF_EXTRACTED.default;
+      setForm((prev) => ({
+        ...prev,
+        ...Object.fromEntries(
+          Object.entries(extracted).filter(([, v]) => v && !prev[_ as keyof ProductForm] || prev[_ as keyof ProductForm] === '')
+            .map(([k, v]) => [k, v])
+        ),
+      }));
+      // 빈 필드만 채우기
+      setForm((prev) => ({
+        name: prev.name || extracted.name || '',
+        category: prev.category || extracted.category || '',
+        price: prev.price || extracted.price || '',
+        description: prev.description || extracted.description || '',
+        ingredients: prev.ingredients || extracted.ingredients || '',
+        usage: prev.usage || extracted.usage || '',
+        manufacturer: prev.manufacturer || extracted.manufacturer || '',
+      }));
+      setPdfState('done');
+    }, 1800);
+  };
+
+  const validate = () => {
+    const errs: Partial<ProductForm> = {};
+    if (!form.name.trim()) errs.name = '상품명을 입력해주세요.';
+    if (!form.category.trim()) errs.category = '카테고리를 입력해주세요.';
+    if (!form.price || isNaN(Number(form.price))) errs.price = '올바른 가격을 입력해주세요.';
+    if (!form.description.trim()) errs.description = '상품 설명을 입력해주세요.';
+    return errs;
+  };
+
+  const handleSave = async () => {
+    const errs = validate();
+    if (Object.keys(errs).length > 0) { setErrors(errs); return; }
+    setIsSaving(true);
+    // TODO: POST /api/v1/products
+    await new Promise((r) => setTimeout(r, 800));
+    router.push('/products');
+  };
+
+  return (
+    <>
+      <Head><title>상품 등록 — Live Platform Lab</title></Head>
+      <style jsx global>{`* { margin:0;padding:0;box-sizing:border-box; } body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:#0f172a; color:#e2e8f0; min-height:100vh; } a { text-decoration:none;color:inherit; }`}</style>
+      <style jsx>{`
+        .container { max-width: 1100px; margin: 0 auto; padding: 40px 24px; }
+        .nav { display: flex; align-items: center; gap: 8px; margin-bottom: 40px; font-size: 13px; color: #64748b; }
+        .nav a:hover { color: #a5b4fc; }
+        .nav-sep { color: #334155; }
+
+        .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 32px; }
+        .page-title { font-size: 26px; font-weight: 800; color: #f1f5f9; }
+        .header-actions { display: flex; gap: 10px; }
+        .btn-cancel { padding: 10px 22px; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); color: #94a3b8; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; transition: background 0.2s; text-decoration: none; display: inline-flex; align-items: center; }
+        .btn-cancel:hover { background: rgba(255,255,255,0.1); }
+        .btn-save { padding: 10px 28px; background: linear-gradient(135deg, #6366f1, #8b5cf6); color: white; border: none; border-radius: 8px; font-size: 14px; font-weight: 700; cursor: pointer; transition: opacity 0.2s; }
+        .btn-save:hover:not(:disabled) { opacity: 0.88; }
+        .btn-save:disabled { opacity: 0.5; cursor: not-allowed; }
+
+        .layout { display: grid; grid-template-columns: 1fr 340px; gap: 24px; align-items: start; }
+
+        /* 좌측 폼 */
+        .form-card { background: #1e293b; border: 1px solid rgba(255,255,255,0.1); border-radius: 16px; padding: 28px; display: flex; flex-direction: column; gap: 20px; }
+        .field { display: flex; flex-direction: column; gap: 6px; }
+        .field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+        .label { font-size: 12px; font-weight: 700; color: #64748b; letter-spacing: 0.04em; text-transform: uppercase; }
+        .input { width: 100%; padding: 11px 14px; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); border-radius: 8px; font-size: 14px; color: #f1f5f9; outline: none; transition: border-color 0.2s, background 0.2s; font-family: inherit; }
+        .input:focus { border-color: #6366f1; background: rgba(99,102,241,0.05); }
+        .input.error { border-color: rgba(239,68,68,0.5); }
+        .input::placeholder { color: #334155; }
+        textarea.input { resize: vertical; min-height: 80px; line-height: 1.6; }
+        .field-error { font-size: 12px; color: #f87171; }
+        .section-divider { height: 1px; background: rgba(255,255,255,0.07); }
+
+        /* 우측 PDF */
+        .right { display: flex; flex-direction: column; gap: 16px; position: sticky; top: 24px; }
+        .pdf-card { background: #1e293b; border: 1px solid rgba(255,255,255,0.1); border-radius: 16px; padding: 22px; }
+        .pdf-title { font-size: 15px; font-weight: 700; color: #f1f5f9; margin-bottom: 4px; }
+        .pdf-sub { font-size: 12px; color: #64748b; margin-bottom: 16px; line-height: 1.55; }
+
+        .drop-zone { border: 1.5px dashed rgba(99,102,241,0.35); border-radius: 10px; padding: 28px 20px; text-align: center; cursor: pointer; transition: border-color 0.2s, background 0.2s; }
+        .drop-zone:hover, .drop-zone.over { border-color: rgba(99,102,241,0.65); background: rgba(99,102,241,0.06); }
+        .drop-icon { font-size: 28px; margin-bottom: 10px; }
+        .drop-text { font-size: 13px; color: #64748b; }
+        .drop-sub { font-size: 11px; color: #334155; margin-top: 4px; }
+
+        .pdf-file { margin-top: 14px; display: flex; align-items: center; gap: 10px; padding: 10px 14px; background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); border-radius: 8px; }
+        .pdf-file-icon { font-size: 20px; flex-shrink: 0; }
+        .pdf-file-info { flex: 1; min-width: 0; }
+        .pdf-file-name { font-size: 13px; font-weight: 600; color: #e2e8f0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .pdf-file-size { font-size: 11px; color: #475569; margin-top: 1px; }
+        .pdf-status { font-size: 11px; font-weight: 700; padding: 3px 9px; border-radius: 999px; flex-shrink: 0; }
+        .pdf-extracting { background: rgba(251,191,36,0.12); color: #fcd34d; border: 1px solid rgba(251,191,36,0.25); }
+        .pdf-done { background: rgba(16,185,129,0.12); color: #6ee7b7; border: 1px solid rgba(16,185,129,0.25); }
+
+        .extract-notice { margin-top: 12px; padding: 10px 14px; background: rgba(16,185,129,0.06); border: 1px solid rgba(16,185,129,0.15); border-radius: 8px; font-size: 12px; color: #6ee7b7; line-height: 1.55; }
+
+        .hint-card { background: #1e293b; border: 1px solid rgba(255,255,255,0.1); border-radius: 16px; padding: 18px 20px; }
+        .hint-title { font-size: 13px; font-weight: 700; color: #94a3b8; margin-bottom: 10px; }
+        .hint-item { font-size: 12px; color: #475569; line-height: 1.7; display: flex; gap: 6px; }
+        .hint-dot { color: #334155; flex-shrink: 0; }
+
+        @media (max-width: 800px) {
+          .layout { grid-template-columns: 1fr; }
+          .right { position: static; }
+          .field-row { grid-template-columns: 1fr; }
+        }
+      `}</style>
+
+      <div className="container">
+        <nav className="nav">
+          <Link href="/">홈</Link>
+          <span className="nav-sep">/</span>
+          <Link href="/products">상품 관리</Link>
+          <span className="nav-sep">/</span>
+          <span style={{ color: '#94a3b8' }}>상품 등록</span>
+        </nav>
+
+        <div className="page-header">
+          <h1 className="page-title">상품 등록</h1>
+          <div className="header-actions">
+            <Link href="/products" className="btn-cancel">취소</Link>
+            <button className="btn-save" onClick={handleSave} disabled={isSaving}>
+              {isSaving ? '저장 중...' : '저장'}
+            </button>
+          </div>
+        </div>
+
+        <div className="layout">
+          {/* 좌측: 입력 폼 */}
+          <div className="form-card">
+            <div className="field-row">
+              <div className="field">
+                <label className="label">상품명 *</label>
+                <input
+                  className={`input ${errors.name ? 'error' : ''}`}
+                  placeholder="예) 워터프루프 립스틱"
+                  value={form.name}
+                  onChange={set('name')}
+                />
+                {errors.name && <span className="field-error">{errors.name}</span>}
+              </div>
+              <div className="field">
+                <label className="label">카테고리 *</label>
+                <input
+                  className={`input ${errors.category ? 'error' : ''}`}
+                  placeholder="예) 뷰티, 스킨케어"
+                  value={form.category}
+                  onChange={set('category')}
+                />
+                {errors.category && <span className="field-error">{errors.category}</span>}
+              </div>
+            </div>
+
+            <div className="field-row">
+              <div className="field">
+                <label className="label">가격 (원) *</label>
+                <input
+                  className={`input ${errors.price ? 'error' : ''}`}
+                  type="number"
+                  placeholder="예) 25000"
+                  value={form.price}
+                  onChange={set('price')}
+                />
+                {errors.price && <span className="field-error">{errors.price}</span>}
+              </div>
+              <div className="field">
+                <label className="label">제조사</label>
+                <input
+                  className="input"
+                  placeholder="예) 뷰티코리아"
+                  value={form.manufacturer}
+                  onChange={set('manufacturer')}
+                />
+              </div>
+            </div>
+
+            <div className="section-divider" />
+
+            <div className="field">
+              <label className="label">상품 설명 *</label>
+              <textarea
+                className={`input ${errors.description ? 'error' : ''}`}
+                placeholder="상품의 특징과 효과를 간결하게 입력하세요."
+                value={form.description}
+                onChange={set('description')}
+                rows={3}
+              />
+              {errors.description && <span className="field-error">{errors.description}</span>}
+            </div>
+
+            <div className="field">
+              <label className="label">주요 성분</label>
+              <textarea
+                className="input"
+                placeholder="예) 정제수, 글리세린, 나이아신아마이드, 히알루론산..."
+                value={form.ingredients}
+                onChange={set('ingredients')}
+                rows={2}
+              />
+            </div>
+
+            <div className="field">
+              <label className="label">사용법</label>
+              <textarea
+                className="input"
+                placeholder="사용 방법과 주의사항을 입력하세요."
+                value={form.usage}
+                onChange={set('usage')}
+                rows={2}
+              />
+            </div>
+          </div>
+
+          {/* 우측: PDF 업로드 */}
+          <div className="right">
+            <div className="pdf-card">
+              <div className="pdf-title">PDF로 자동 입력</div>
+              <div className="pdf-sub">상품 설명서나 성분표 PDF를 업로드하면 AI가 내용을 분석해 자동으로 채워드립니다.</div>
+
+              <div
+                className={`drop-zone ${isDragOver ? 'over' : ''}`}
+                onClick={() => fileInputRef.current?.click()}
+                onDragOver={(e) => { e.preventDefault(); setIsDragOver(true); }}
+                onDragLeave={() => setIsDragOver(false)}
+                onDrop={(e) => { e.preventDefault(); setIsDragOver(false); handlePdf(e.dataTransfer.files); }}
+              >
+                <div className="drop-icon">📄</div>
+                <div className="drop-text">PDF를 드래그하거나 클릭하여 업로드</div>
+                <div className="drop-sub">AI가 상품 정보를 자동으로 추출합니다</div>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".pdf"
+                  style={{ display: 'none' }}
+                  onChange={(e) => handlePdf(e.target.files)}
+                />
+              </div>
+
+              {pdfFile && (
+                <>
+                  <div className="pdf-file">
+                    <span className="pdf-file-icon">📄</span>
+                    <div className="pdf-file-info">
+                      <div className="pdf-file-name">{pdfFile.name}</div>
+                      <div className="pdf-file-size">{pdfFile.size}</div>
+                    </div>
+                    <span className={`pdf-status ${pdfState === 'extracting' ? 'pdf-extracting' : 'pdf-done'}`}>
+                      {pdfState === 'extracting' ? '분석 중...' : '완료'}
+                    </span>
+                  </div>
+                  {pdfState === 'done' && (
+                    <div className="extract-notice">
+                      PDF에서 상품 정보를 추출했습니다. 내용을 확인하고 필요하면 수정해주세요.
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+
+            <div className="hint-card">
+              <div className="hint-title">입력 가이드</div>
+              <div className="hint-item"><span className="hint-dot">·</span>상품 설명은 AI Q&A 답변의 주요 근거로 활용됩니다.</div>
+              <div className="hint-item"><span className="hint-dot">·</span>성분 정보를 상세히 입력할수록 정확한 답변이 가능합니다.</div>
+              <div className="hint-item"><span className="hint-dot">·</span>저장 후 상품 상세 페이지에서 추가 문서를 업로드할 수 있습니다.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
프론트엔드 주요 페이지(방송 목록/상세/등록, 상품 목록/상세/등록, 채팅, 포트폴리오)를 신규 구성하고, 방송 등록 화면의 상품 선택을 단일 선택에서 N개 다중 선택 방식으로 개선하였습니다.


### Issue
- closes #38


### Why
- 라이브 쇼핑 플랫폼의 핵심 UI 화면이 부재하여 서비스 흐름 확인 및 백엔드 연동이 불가능한 상태
- 방송 등록 시 1개 상품만 연결할 수 있어 다중 상품 방송 시나리오를 지원하지 못함


### What
- `index.tsx`: 메인 페이지 화면 분리 및 재구성, 방송 목록 보기 버튼 margin-top 적용
- `broadcasts.tsx`: 방송 목록 페이지 신규 작성
- `broadcasts/new.tsx`: 방송 등록 페이지 신규 작성
  - 상품 선택을 단일(`selectedProductId`) → 다중(`selectedProductIds: string[]`)으로 변경
  - 방송 상세 페이지와 동일한 셀렉박스(피커) UI 적용 — `+ 상품 추가` 버튼으로 토글, 선택된 상품은 카드 목록으로 표시하며 `✕`로 개별 제거 가능
- `broadcasts/[id].tsx`: 방송 상세 페이지 신규 작성 (다중 상품 연결, 피커 UI 포함)
- `chat.tsx`: 채팅 화면 신규 작성
- `products.tsx`: 상품 목록 페이지 신규 작성
- `products/[id].tsx`: 상품 상세 페이지 신규 작성
- `products/new.tsx`: 상품 등록 페이지 신규 작성


### How
- Next.js Pages Router 기반으로 각 도메인별 페이지 파일 분리
- 상품 다중 선택: `toggleProduct` 함수로 배열 상태 토글, 유효성 검사는 `length === 0` 조건으로 변경
- 피커 UI는 방송 상세 페이지(`[id].tsx`)의 `.product-picker` 패턴을 방송 등록 페이지에도 동일하게 적용하여 일관된 UX 제공
- 현재는 Mock 데이터 사용, 추후 `POST /api/v1/broadcasts` 등 API 연동 예정


### Test
- 브라우저에서 각 페이지 직접 접근하여 레이아웃 및 인터랙션 확인
- 방송 등록 페이지에서 상품 여러 개 선택/해제 동작 확인
- 유효성 검사(제목 미입력, 상품 미선택) 에러 메시지 노출 확인