### PR TITLE
[#47] feat: 캠페인 도메인 CRUD API 및 웹 클라이언트 연동 구현

### DIFF
--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/controller/campaign/CampaignController.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/controller/campaign/CampaignController.java
@@ -6,8 +6,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.giglab.live.commerce.api.dto.campaign.CreateCampaignRequest;
 import org.giglab.live.commerce.api.dto.campaign.CreateCampaignResponse;
+import org.giglab.live.commerce.api.dto.campaign.GetCampaignListRequest;
+import org.giglab.live.commerce.api.dto.campaign.GetCampaignListResponse;
 import org.giglab.live.commerce.api.facade.CampaignFacade;
 import org.giglab.live.commerce.api.response.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +23,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class CampaignController {
 
   private final CampaignFacade campaignFacade;
+
+  @Operation(summary = "캠페인 목록 조회", description = "커서 기반 페이지네이션으로 캠페인 목록을 조회합니다.")
+  @GetMapping
+  public ApiResponse<GetCampaignListResponse> getList(@Valid GetCampaignListRequest request) {
+    return ApiResponse.success(campaignFacade.getList(request));
+  }
 
   @Operation(summary = "캠페인 등록", description = "캠페인을 등록합니다.")
   @PostMapping

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/controller/campaign/CampaignController.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/controller/campaign/CampaignController.java
@@ -8,9 +8,11 @@ import org.giglab.live.commerce.api.dto.campaign.CreateCampaignRequest;
 import org.giglab.live.commerce.api.dto.campaign.CreateCampaignResponse;
 import org.giglab.live.commerce.api.dto.campaign.GetCampaignListRequest;
 import org.giglab.live.commerce.api.dto.campaign.GetCampaignListResponse;
+import org.giglab.live.commerce.api.dto.campaign.GetCampaignResponse;
 import org.giglab.live.commerce.api.facade.CampaignFacade;
 import org.giglab.live.commerce.api.response.ApiResponse;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,6 +30,12 @@ public class CampaignController {
   @GetMapping
   public ApiResponse<GetCampaignListResponse> getList(@Valid GetCampaignListRequest request) {
     return ApiResponse.success(campaignFacade.getList(request));
+  }
+
+  @Operation(summary = "캠페인 상세 조회", description = "캠페인 ID로 캠페인 상세 정보를 조회합니다.")
+  @GetMapping("/{campaignId}")
+  public ApiResponse<GetCampaignResponse> getDetail(@PathVariable Long campaignId) {
+    return ApiResponse.success(campaignFacade.getDetail(campaignId));
   }
 
   @Operation(summary = "캠페인 등록", description = "캠페인을 등록합니다.")

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/controller/campaign/CampaignController.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/controller/campaign/CampaignController.java
@@ -1,0 +1,30 @@
+package org.giglab.live.commerce.api.controller.campaign;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.api.dto.campaign.CreateCampaignRequest;
+import org.giglab.live.commerce.api.dto.campaign.CreateCampaignResponse;
+import org.giglab.live.commerce.api.facade.CampaignFacade;
+import org.giglab.live.commerce.api.response.ApiResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Campaign", description = "캠페인 API")
+@RestController
+@RequestMapping("/campaigns")
+@RequiredArgsConstructor
+public class CampaignController {
+
+  private final CampaignFacade campaignFacade;
+
+  @Operation(summary = "캠페인 등록", description = "캠페인을 등록합니다.")
+  @PostMapping
+  public ApiResponse<CreateCampaignResponse> create(
+      @RequestBody @Valid CreateCampaignRequest request) {
+    return ApiResponse.success(campaignFacade.create(request));
+  }
+}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/CampaignProductItem.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/CampaignProductItem.java
@@ -1,0 +1,3 @@
+package org.giglab.live.commerce.api.dto.campaign;
+
+public record CampaignProductItem(Long productId, String name, int displayOrder) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/CampaignProductRequest.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/CampaignProductRequest.java
@@ -1,5 +1,7 @@
 package org.giglab.live.commerce.api.dto.campaign;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record CampaignProductRequest(@NotNull Long productId, String name, int displayOrder) {}
+public record CampaignProductRequest(
+    @NotNull Long productId, @NotBlank String name, int displayOrder) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/CampaignProductRequest.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/CampaignProductRequest.java
@@ -1,0 +1,5 @@
+package org.giglab.live.commerce.api.dto.campaign;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CampaignProductRequest(@NotNull Long productId, int displayOrder) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/CampaignProductRequest.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/CampaignProductRequest.java
@@ -2,4 +2,4 @@ package org.giglab.live.commerce.api.dto.campaign;
 
 import jakarta.validation.constraints.NotNull;
 
-public record CampaignProductRequest(@NotNull Long productId, int displayOrder) {}
+public record CampaignProductRequest(@NotNull Long productId, String name, int displayOrder) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/CampaignSummaryItem.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/CampaignSummaryItem.java
@@ -1,0 +1,11 @@
+package org.giglab.live.commerce.api.dto.campaign;
+
+import java.time.LocalDateTime;
+
+public record CampaignSummaryItem(
+    Long id,
+    String title,
+    String description,
+    String status,
+    LocalDateTime scheduledAt,
+    int productCount) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/CreateCampaignRequest.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/CreateCampaignRequest.java
@@ -1,0 +1,14 @@
+package org.giglab.live.commerce.api.dto.campaign;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CreateCampaignRequest(
+    @NotBlank String title,
+    @NotBlank String description,
+    @NotNull LocalDateTime scheduledAt,
+    @Size(min = 1) @NotNull @Valid List<CampaignProductRequest> campaignProducts) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/CreateCampaignResponse.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/CreateCampaignResponse.java
@@ -1,0 +1,3 @@
+package org.giglab.live.commerce.api.dto.campaign;
+
+public record CreateCampaignResponse(Long campaignId) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/GetCampaignListRequest.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/GetCampaignListRequest.java
@@ -1,0 +1,6 @@
+package org.giglab.live.commerce.api.dto.campaign;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record GetCampaignListRequest(Long cursor, @Min(1) @Max(100) Integer size, String keyword) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/GetCampaignListResponse.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/GetCampaignListResponse.java
@@ -1,0 +1,6 @@
+package org.giglab.live.commerce.api.dto.campaign;
+
+import java.util.List;
+
+public record GetCampaignListResponse(
+    List<CampaignSummaryItem> items, Long nextCursor, boolean hasNext) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/GetCampaignResponse.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/GetCampaignResponse.java
@@ -1,0 +1,14 @@
+package org.giglab.live.commerce.api.dto.campaign;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GetCampaignResponse(
+    Long id,
+    String title,
+    String description,
+    String status,
+    LocalDateTime scheduledAt,
+    LocalDateTime startedAt,
+    LocalDateTime endedAt,
+    List<CampaignProductItem> campaignProducts) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/product/GetProductListRequest.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/product/GetProductListRequest.java
@@ -3,4 +3,4 @@ package org.giglab.live.commerce.api.dto.product;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
-public record GetProductListRequest(Long cursor, @Min(1) @Max(100) Integer size) {}
+public record GetProductListRequest(Long cursor, @Min(1) @Max(100) Integer size, String keyword) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/facade/CampaignFacade.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/facade/CampaignFacade.java
@@ -3,10 +3,13 @@ package org.giglab.live.commerce.api.facade;
 import lombok.RequiredArgsConstructor;
 import org.giglab.live.commerce.api.dto.campaign.CreateCampaignRequest;
 import org.giglab.live.commerce.api.dto.campaign.CreateCampaignResponse;
+import org.giglab.live.commerce.api.dto.campaign.GetCampaignListRequest;
+import org.giglab.live.commerce.api.dto.campaign.GetCampaignListResponse;
 import org.giglab.live.commerce.api.mapper.campaign.CampaignMapper;
 import org.giglab.live.commerce.core.campaign.application.CampaignService;
 import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignCommand;
 import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignResult;
+import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignListResult;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,6 +18,12 @@ public class CampaignFacade {
 
   private final CampaignMapper campaignMapper;
   private final CampaignService campaignService;
+
+  public GetCampaignListResponse getList(GetCampaignListRequest request) {
+    GetCampaignListResult result =
+        campaignService.getList(campaignMapper.toCampaignListQuery(request));
+    return campaignMapper.toGetCampaignListResponse(result);
+  }
 
   public CreateCampaignResponse create(CreateCampaignRequest request) {
     CreateCampaignCommand command = campaignMapper.toCreateCampaignCommand(request);

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/facade/CampaignFacade.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/facade/CampaignFacade.java
@@ -5,11 +5,13 @@ import org.giglab.live.commerce.api.dto.campaign.CreateCampaignRequest;
 import org.giglab.live.commerce.api.dto.campaign.CreateCampaignResponse;
 import org.giglab.live.commerce.api.dto.campaign.GetCampaignListRequest;
 import org.giglab.live.commerce.api.dto.campaign.GetCampaignListResponse;
+import org.giglab.live.commerce.api.dto.campaign.GetCampaignResponse;
 import org.giglab.live.commerce.api.mapper.campaign.CampaignMapper;
 import org.giglab.live.commerce.core.campaign.application.CampaignService;
 import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignCommand;
 import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignResult;
 import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignListResult;
+import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,6 +25,11 @@ public class CampaignFacade {
     GetCampaignListResult result =
         campaignService.getList(campaignMapper.toCampaignListQuery(request));
     return campaignMapper.toGetCampaignListResponse(result);
+  }
+
+  public GetCampaignResponse getDetail(Long campaignId) {
+    GetCampaignResult result = campaignService.getDetail(campaignId);
+    return campaignMapper.toGetCampaignResponse(result);
   }
 
   public CreateCampaignResponse create(CreateCampaignRequest request) {

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/facade/CampaignFacade.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/facade/CampaignFacade.java
@@ -1,0 +1,24 @@
+package org.giglab.live.commerce.api.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.api.dto.campaign.CreateCampaignRequest;
+import org.giglab.live.commerce.api.dto.campaign.CreateCampaignResponse;
+import org.giglab.live.commerce.api.mapper.campaign.CampaignMapper;
+import org.giglab.live.commerce.core.campaign.application.CampaignService;
+import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignCommand;
+import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignResult;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CampaignFacade {
+
+  private final CampaignMapper campaignMapper;
+  private final CampaignService campaignService;
+
+  public CreateCampaignResponse create(CreateCampaignRequest request) {
+    CreateCampaignCommand command = campaignMapper.toCreateCampaignCommand(request);
+    CreateCampaignResult result = campaignService.create(command);
+    return campaignMapper.toCreateCampaignResponse(result);
+  }
+}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/mapper/campaign/CampaignMapper.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/mapper/campaign/CampaignMapper.java
@@ -1,0 +1,19 @@
+package org.giglab.live.commerce.api.mapper.campaign;
+
+import org.giglab.live.commerce.api.dto.campaign.CampaignProductRequest;
+import org.giglab.live.commerce.api.dto.campaign.CreateCampaignRequest;
+import org.giglab.live.commerce.api.dto.campaign.CreateCampaignResponse;
+import org.giglab.live.commerce.core.campaign.application.dto.CampaignProductDto;
+import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignCommand;
+import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignResult;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface CampaignMapper {
+
+  CreateCampaignCommand toCreateCampaignCommand(CreateCampaignRequest request);
+
+  CampaignProductDto toCampaignProductDto(CampaignProductRequest request);
+
+  CreateCampaignResponse toCreateCampaignResponse(CreateCampaignResult result);
+}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/mapper/campaign/CampaignMapper.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/mapper/campaign/CampaignMapper.java
@@ -1,12 +1,19 @@
 package org.giglab.live.commerce.api.mapper.campaign;
 
 import org.giglab.live.commerce.api.dto.campaign.CampaignProductRequest;
+import org.giglab.live.commerce.api.dto.campaign.CampaignSummaryItem;
 import org.giglab.live.commerce.api.dto.campaign.CreateCampaignRequest;
 import org.giglab.live.commerce.api.dto.campaign.CreateCampaignResponse;
+import org.giglab.live.commerce.api.dto.campaign.GetCampaignListRequest;
+import org.giglab.live.commerce.api.dto.campaign.GetCampaignListResponse;
+import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignProductDto;
+import org.giglab.live.commerce.core.campaign.application.dto.CampaignSummary;
 import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignCommand;
 import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignResult;
+import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignListResult;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface CampaignMapper {
@@ -16,4 +23,12 @@ public interface CampaignMapper {
   CampaignProductDto toCampaignProductDto(CampaignProductRequest request);
 
   CreateCampaignResponse toCreateCampaignResponse(CreateCampaignResult result);
+
+  @Mapping(target = "size", expression = "java(request.size() != null ? request.size() : 20)")
+  CampaignListQuery toCampaignListQuery(GetCampaignListRequest request);
+
+  @Mapping(target = "status", expression = "java(summary.status().name())")
+  CampaignSummaryItem toCampaignSummaryItem(CampaignSummary summary);
+
+  GetCampaignListResponse toGetCampaignListResponse(GetCampaignListResult result);
 }

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/mapper/campaign/CampaignMapper.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/mapper/campaign/CampaignMapper.java
@@ -1,17 +1,20 @@
 package org.giglab.live.commerce.api.mapper.campaign;
 
+import org.giglab.live.commerce.api.dto.campaign.CampaignProductItem;
 import org.giglab.live.commerce.api.dto.campaign.CampaignProductRequest;
 import org.giglab.live.commerce.api.dto.campaign.CampaignSummaryItem;
 import org.giglab.live.commerce.api.dto.campaign.CreateCampaignRequest;
 import org.giglab.live.commerce.api.dto.campaign.CreateCampaignResponse;
 import org.giglab.live.commerce.api.dto.campaign.GetCampaignListRequest;
 import org.giglab.live.commerce.api.dto.campaign.GetCampaignListResponse;
+import org.giglab.live.commerce.api.dto.campaign.GetCampaignResponse;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignProductDto;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignSummary;
 import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignCommand;
 import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignResult;
 import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignListResult;
+import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -31,4 +34,9 @@ public interface CampaignMapper {
   CampaignSummaryItem toCampaignSummaryItem(CampaignSummary summary);
 
   GetCampaignListResponse toGetCampaignListResponse(GetCampaignListResult result);
+
+  CampaignProductItem toCampaignProductItem(CampaignProductDto dto);
+
+  @Mapping(target = "status", expression = "java(result.status().name())")
+  GetCampaignResponse toGetCampaignResponse(GetCampaignResult result);
 }

--- a/live-commerce-api/src/main/resources/application-local.yml
+++ b/live-commerce-api/src/main/resources/application-local.yml
@@ -1,6 +1,5 @@
 cors:
-  allowed-origins:
-    - http://localhost:3000
+  allowed-origins: http://localhost:3000
 
 spring:
   config:

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
@@ -5,8 +5,10 @@ import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
 import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignCommand;
 import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignResult;
 import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignListResult;
+import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
 import org.giglab.live.commerce.core.campaign.application.usecase.CreateCampaignUseCase;
 import org.giglab.live.commerce.core.campaign.application.usecase.GetCampaignListUseCase;
+import org.giglab.live.commerce.core.campaign.application.usecase.GetCampaignUseCase;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,10 +16,15 @@ import org.springframework.stereotype.Service;
 public class CampaignService {
 
   private final GetCampaignListUseCase getCampaignListUseCase;
+  private final GetCampaignUseCase getCampaignUseCase;
   private final CreateCampaignUseCase createCampaignUseCase;
 
   public GetCampaignListResult getList(CampaignListQuery query) {
     return getCampaignListUseCase.execute(query);
+  }
+
+  public GetCampaignResult getDetail(Long campaignId) {
+    return getCampaignUseCase.execute(campaignId);
   }
 
   public CreateCampaignResult create(CreateCampaignCommand request) {

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
@@ -1,16 +1,24 @@
 package org.giglab.live.commerce.core.campaign.application;
 
 import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
 import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignCommand;
 import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignResult;
+import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignListResult;
 import org.giglab.live.commerce.core.campaign.application.usecase.CreateCampaignUseCase;
+import org.giglab.live.commerce.core.campaign.application.usecase.GetCampaignListUseCase;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class CampaignService {
 
+  private final GetCampaignListUseCase getCampaignListUseCase;
   private final CreateCampaignUseCase createCampaignUseCase;
+
+  public GetCampaignListResult getList(CampaignListQuery query) {
+    return getCampaignListUseCase.execute(query);
+  }
 
   public CreateCampaignResult create(CreateCampaignCommand request) {
     return createCampaignUseCase.execute(request);

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
@@ -1,0 +1,18 @@
+package org.giglab.live.commerce.core.campaign.application;
+
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignCommand;
+import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignResult;
+import org.giglab.live.commerce.core.campaign.application.usecase.CreateCampaignUseCase;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CampaignService {
+
+  private final CreateCampaignUseCase createCampaignUseCase;
+
+  public CreateCampaignResult create(CreateCampaignCommand request) {
+    return createCampaignUseCase.execute(request);
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/CampaignListQuery.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/CampaignListQuery.java
@@ -1,0 +1,9 @@
+package org.giglab.live.commerce.core.campaign.application.dto;
+
+import org.giglab.live.commerce.core.campaign.domain.entity.types.BroadcastStatusType;
+
+public record CampaignListQuery(Long cursor, int size, String keyword, BroadcastStatusType status) {
+  public int fetchSize() {
+    return size + 1;
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/CampaignProductDto.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/CampaignProductDto.java
@@ -1,0 +1,3 @@
+package org.giglab.live.commerce.core.campaign.application.dto;
+
+public record CampaignProductDto(Long productId, int displayOrder) {}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/CampaignProductDto.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/CampaignProductDto.java
@@ -1,3 +1,3 @@
 package org.giglab.live.commerce.core.campaign.application.dto;
 
-public record CampaignProductDto(Long productId, int displayOrder) {}
+public record CampaignProductDto(Long productId, String name, int displayOrder) {}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/CampaignSummary.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/CampaignSummary.java
@@ -1,0 +1,12 @@
+package org.giglab.live.commerce.core.campaign.application.dto;
+
+import java.time.LocalDateTime;
+import org.giglab.live.commerce.core.campaign.domain.entity.types.BroadcastStatusType;
+
+public record CampaignSummary(
+    Long id,
+    String title,
+    String description,
+    BroadcastStatusType status,
+    LocalDateTime scheduledAt,
+    int productCount) {}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/CreateCampaignCommand.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/CreateCampaignCommand.java
@@ -1,0 +1,13 @@
+package org.giglab.live.commerce.core.campaign.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CreateCampaignCommand(
+    @NotBlank String title,
+    @NotBlank String description,
+    @NotNull LocalDateTime scheduledAt,
+    @Size(min = 1) @NotNull List<CampaignProductDto> campaignProducts) {}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/CreateCampaignResult.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/CreateCampaignResult.java
@@ -1,0 +1,3 @@
+package org.giglab.live.commerce.core.campaign.application.dto;
+
+public record CreateCampaignResult(Long campaignId) {}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/GetCampaignListResult.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/GetCampaignListResult.java
@@ -1,0 +1,13 @@
+package org.giglab.live.commerce.core.campaign.application.dto;
+
+import java.util.List;
+
+public record GetCampaignListResult(List<CampaignSummary> items, Long nextCursor, boolean hasNext) {
+
+  public static GetCampaignListResult of(List<CampaignSummary> fetched, int requestedSize) {
+    boolean hasNext = fetched.size() > requestedSize;
+    List<CampaignSummary> items = hasNext ? fetched.subList(0, requestedSize) : fetched;
+    Long nextCursor = hasNext ? items.getLast().id() : null;
+    return new GetCampaignListResult(items, nextCursor, hasNext);
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/GetCampaignResult.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/GetCampaignResult.java
@@ -1,0 +1,15 @@
+package org.giglab.live.commerce.core.campaign.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.giglab.live.commerce.core.campaign.domain.entity.types.BroadcastStatusType;
+
+public record GetCampaignResult(
+    Long id,
+    String title,
+    String description,
+    BroadcastStatusType status,
+    LocalDateTime scheduledAt,
+    LocalDateTime startedAt,
+    LocalDateTime endedAt,
+    List<CampaignProductDto> campaignProducts) {}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/port/persistence/CampaignQueryPort.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/port/persistence/CampaignQueryPort.java
@@ -1,0 +1,9 @@
+package org.giglab.live.commerce.core.campaign.application.port.persistence;
+
+import java.util.List;
+import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
+import org.giglab.live.commerce.core.campaign.application.dto.CampaignSummary;
+
+public interface CampaignQueryPort {
+  List<CampaignSummary> findList(CampaignListQuery query);
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/port/persistence/CampaignQueryPort.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/port/persistence/CampaignQueryPort.java
@@ -1,9 +1,13 @@
 package org.giglab.live.commerce.core.campaign.application.port.persistence;
 
 import java.util.List;
+import java.util.Optional;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignSummary;
+import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
 
 public interface CampaignQueryPort {
   List<CampaignSummary> findList(CampaignListQuery query);
+
+  Optional<GetCampaignResult> findById(Long campaignId);
 }

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/port/persistence/CampaignStorePort.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/port/persistence/CampaignStorePort.java
@@ -1,0 +1,7 @@
+package org.giglab.live.commerce.core.campaign.application.port.persistence;
+
+import org.giglab.live.commerce.core.campaign.domain.entity.Campaign;
+
+public interface CampaignStorePort {
+  Campaign store(Campaign newCampaign);
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/CreateCampaignUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/CreateCampaignUseCase.java
@@ -1,0 +1,31 @@
+package org.giglab.live.commerce.core.campaign.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.core.campaign.application.dto.CampaignProductDto;
+import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignCommand;
+import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignResult;
+import org.giglab.live.commerce.core.campaign.application.port.persistence.CampaignStorePort;
+import org.giglab.live.commerce.core.campaign.domain.entity.Campaign;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CreateCampaignUseCase {
+
+  private final CampaignStorePort campaignStorePort;
+
+  public CreateCampaignResult execute(CreateCampaignCommand command) {
+
+    Campaign campaign =
+        Campaign.create(command.title(), command.description(), command.scheduledAt());
+
+    for (CampaignProductDto product : command.campaignProducts()) {
+      campaign.addProduct(product.productId(), product.displayOrder());
+    }
+
+    Campaign savedCampaign = campaignStorePort.store(campaign);
+    return new CreateCampaignResult(savedCampaign.getId());
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/CreateCampaignUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/CreateCampaignUseCase.java
@@ -22,7 +22,7 @@ public class CreateCampaignUseCase {
         Campaign.create(command.title(), command.description(), command.scheduledAt());
 
     for (CampaignProductDto product : command.campaignProducts()) {
-      campaign.addProduct(product.productId(), product.displayOrder());
+      campaign.addProduct(product.productId(), product.name(), product.displayOrder());
     }
 
     Campaign savedCampaign = campaignStorePort.store(campaign);

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/GetCampaignListUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/GetCampaignListUseCase.java
@@ -1,0 +1,23 @@
+package org.giglab.live.commerce.core.campaign.application.usecase;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
+import org.giglab.live.commerce.core.campaign.application.dto.CampaignSummary;
+import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignListResult;
+import org.giglab.live.commerce.core.campaign.application.port.persistence.CampaignQueryPort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetCampaignListUseCase {
+
+  private final CampaignQueryPort campaignQueryPort;
+
+  public GetCampaignListResult execute(CampaignListQuery query) {
+    List<CampaignSummary> fetched = campaignQueryPort.findList(query);
+    return GetCampaignListResult.of(fetched, query.size());
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/GetCampaignUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/GetCampaignUseCase.java
@@ -1,0 +1,27 @@
+package org.giglab.live.commerce.core.campaign.application.usecase;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
+import org.giglab.live.commerce.core.campaign.application.port.persistence.CampaignQueryPort;
+import org.giglab.live.commerce.core.campaign.domain.exception.CampaignDomainException;
+import org.giglab.live.commerce.core.campaign.domain.exception.CampaignErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetCampaignUseCase {
+
+  private final CampaignQueryPort campaignQueryPort;
+
+  public GetCampaignResult execute(Long campaignId) {
+    Optional<GetCampaignResult> findDetail = campaignQueryPort.findById(campaignId);
+    if (findDetail.isEmpty()) {
+      throw new CampaignDomainException(
+          CampaignErrorCode.NOT_FOUND, String.format("존재하지 않는 캠페인 %d 입니다.", campaignId));
+    }
+    return findDetail.get();
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/Campaign.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/Campaign.java
@@ -65,7 +65,11 @@ public class Campaign extends AuditedEntity {
   private LocalDateTime endedAt;
 
   public static Campaign create(String title, String description, LocalDateTime scheduledAt) {
-    return Campaign.builder().title(title).scheduledAt(scheduledAt).build();
+    return Campaign.builder()
+        .title(title)
+        .description(description)
+        .scheduledAt(scheduledAt)
+        .build();
   }
 
   public void addProduct(Long productId, int displayOrder) {

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/Campaign.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/Campaign.java
@@ -1,0 +1,74 @@
+package org.giglab.live.commerce.core.campaign.domain.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.giglab.live.commerce.core.campaign.domain.entity.types.BroadcastStatusType;
+import org.giglab.live.commerce.core.global.jpa.entity.AuditedEntity;
+import org.giglab.live.commerce.core.global.jpa.entity.types.YnType;
+
+@Getter
+@Builder
+@Entity
+@Table(name = "campaigns")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Campaign extends AuditedEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Builder.Default
+  @OneToMany(
+      mappedBy = "campaign",
+      fetch = FetchType.LAZY,
+      cascade = {CascadeType.PERSIST, CascadeType.MERGE},
+      orphanRemoval = true)
+  private List<CampaignProduct> campaignProducts = new ArrayList<>();
+
+  @Builder.Default
+  @Column(columnDefinition = "varchar(2) default 'N'", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private YnType deleteYn = YnType.N;
+
+  @Column(nullable = false, length = 100)
+  private String title;
+
+  private String description;
+
+  @Builder.Default
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private BroadcastStatusType status = BroadcastStatusType.SCHEDULED;
+
+  private LocalDateTime scheduledAt;
+
+  private LocalDateTime startedAt;
+
+  private LocalDateTime endedAt;
+
+  public static Campaign create(String title, String description, LocalDateTime scheduledAt) {
+    return Campaign.builder().title(title).scheduledAt(scheduledAt).build();
+  }
+
+  public void addProduct(Long productId, int displayOrder) {
+    this.campaignProducts.add(CampaignProduct.of(this, productId, displayOrder));
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/Campaign.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/Campaign.java
@@ -72,7 +72,7 @@ public class Campaign extends AuditedEntity {
         .build();
   }
 
-  public void addProduct(Long productId, int displayOrder) {
-    this.campaignProducts.add(CampaignProduct.of(this, productId, displayOrder));
+  public void addProduct(Long productId, String name, int displayOrder) {
+    this.campaignProducts.add(CampaignProduct.of(this, productId, name, displayOrder));
   }
 }

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/CampaignProduct.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/CampaignProduct.java
@@ -32,7 +32,7 @@ public class CampaignProduct extends AuditedEntity {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "product_id", nullable = false)
+  @JoinColumn(name = "campaign_id", nullable = false)
   private Campaign campaign;
 
   @Column(name = "product_id", nullable = false)

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/CampaignProduct.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/CampaignProduct.java
@@ -1,0 +1,51 @@
+package org.giglab.live.commerce.core.campaign.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.giglab.live.commerce.core.global.jpa.entity.AuditedEntity;
+
+@Getter
+@Builder
+@Entity
+@Table(
+    name = "campaign_products",
+    uniqueConstraints = {@UniqueConstraint(columnNames = {"campaign_id", "product_id"})})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CampaignProduct extends AuditedEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "product_id", nullable = false)
+  private Campaign campaign;
+
+  @Column(name = "product_id", nullable = false)
+  private Long productId;
+
+  @Column(nullable = false)
+  private int displayOrder;
+
+  protected static CampaignProduct of(Campaign campaign, Long productId, int displayOrder) {
+    return CampaignProduct.builder()
+        .campaign(campaign)
+        .productId(productId)
+        .displayOrder(displayOrder)
+        .build();
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/CampaignProduct.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/CampaignProduct.java
@@ -39,12 +39,17 @@ public class CampaignProduct extends AuditedEntity {
   private Long productId;
 
   @Column(nullable = false)
+  private String name;
+
+  @Column(nullable = false)
   private int displayOrder;
 
-  protected static CampaignProduct of(Campaign campaign, Long productId, int displayOrder) {
+  protected static CampaignProduct of(
+      Campaign campaign, Long productId, String name, int displayOrder) {
     return CampaignProduct.builder()
         .campaign(campaign)
         .productId(productId)
+        .name(name)
         .displayOrder(displayOrder)
         .build();
   }

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/types/BroadcastStatusType.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/types/BroadcastStatusType.java
@@ -1,0 +1,15 @@
+package org.giglab.live.commerce.core.campaign.domain.entity.types;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BroadcastStatusType {
+  SCHEDULED("Scheduled", "방송 예정"),
+  ON_AIR("OnAir", "방송 중"),
+  ENDED("Ended", "방송 종료");
+
+  private final String key;
+  private final String description;
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/exception/CampaignDomainException.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/exception/CampaignDomainException.java
@@ -1,0 +1,14 @@
+package org.giglab.live.commerce.core.campaign.domain.exception;
+
+import org.giglab.live.commerce.core.global.exception.DomainException;
+
+public class CampaignDomainException extends DomainException {
+
+  public CampaignDomainException(CampaignErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public CampaignDomainException(CampaignErrorCode errorCode, String message) {
+    super(errorCode, message);
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/exception/CampaignErrorCode.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/exception/CampaignErrorCode.java
@@ -1,0 +1,14 @@
+package org.giglab.live.commerce.core.campaign.domain.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.core.global.exception.DomainErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum CampaignErrorCode implements DomainErrorCode {
+  NOT_FOUND("CAMPAIGN-4401", "존재하지 않는 캠페인입니다.");
+
+  private final String code;
+  private final String message;
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/adapter/JpaCampaignQueryAdapter.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/adapter/JpaCampaignQueryAdapter.java
@@ -1,0 +1,21 @@
+package org.giglab.live.commerce.core.campaign.infrastructure.adapter;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
+import org.giglab.live.commerce.core.campaign.application.dto.CampaignSummary;
+import org.giglab.live.commerce.core.campaign.application.port.persistence.CampaignQueryPort;
+import org.giglab.live.commerce.core.campaign.infrastructure.persistence.CampaignQueryRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JpaCampaignQueryAdapter implements CampaignQueryPort {
+
+  private final CampaignQueryRepository queryRepository;
+
+  @Override
+  public List<CampaignSummary> findList(CampaignListQuery query) {
+    return queryRepository.findList(query);
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/adapter/JpaCampaignQueryAdapter.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/adapter/JpaCampaignQueryAdapter.java
@@ -1,9 +1,11 @@
 package org.giglab.live.commerce.core.campaign.infrastructure.adapter;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignSummary;
+import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
 import org.giglab.live.commerce.core.campaign.application.port.persistence.CampaignQueryPort;
 import org.giglab.live.commerce.core.campaign.infrastructure.persistence.CampaignQueryRepository;
 import org.springframework.stereotype.Component;
@@ -17,5 +19,10 @@ public class JpaCampaignQueryAdapter implements CampaignQueryPort {
   @Override
   public List<CampaignSummary> findList(CampaignListQuery query) {
     return queryRepository.findList(query);
+  }
+
+  @Override
+  public Optional<GetCampaignResult> findById(Long id) {
+    return queryRepository.findById(id);
   }
 }

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/adapter/JpaCampaignStoreAdapter.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/adapter/JpaCampaignStoreAdapter.java
@@ -1,0 +1,19 @@
+package org.giglab.live.commerce.core.campaign.infrastructure.adapter;
+
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.core.campaign.application.port.persistence.CampaignStorePort;
+import org.giglab.live.commerce.core.campaign.domain.entity.Campaign;
+import org.giglab.live.commerce.core.campaign.infrastructure.persistence.CampaignRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JpaCampaignStoreAdapter implements CampaignStorePort {
+
+  private final CampaignRepository campaignRepository;
+
+  @Override
+  public Campaign store(Campaign newCampaign) {
+    return campaignRepository.save(newCampaign);
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/persistence/CampaignQueryRepository.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/persistence/CampaignQueryRepository.java
@@ -1,0 +1,58 @@
+package org.giglab.live.commerce.core.campaign.infrastructure.persistence;
+
+import static org.giglab.live.commerce.core.campaign.domain.entity.QCampaign.campaign;
+import static org.giglab.live.commerce.core.campaign.domain.entity.QCampaignProduct.campaignProduct;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
+import org.giglab.live.commerce.core.campaign.application.dto.CampaignSummary;
+import org.giglab.live.commerce.core.global.jpa.entity.types.YnType;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class CampaignQueryRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  public List<CampaignSummary> findList(CampaignListQuery query) {
+    BooleanBuilder builder = new BooleanBuilder();
+    builder.and(campaign.deleteYn.eq(YnType.N));
+
+    if (query.cursor() != null) {
+      builder.and(campaign.id.lt(query.cursor()));
+    }
+
+    if (query.status() != null) {
+      builder.and(campaign.status.eq(query.status()));
+    }
+
+    if (StringUtils.hasText(query.keyword())) {
+      builder.and(campaign.title.containsIgnoreCase(query.keyword()));
+    }
+
+    return queryFactory
+        .select(
+            Projections.constructor(
+                CampaignSummary.class,
+                campaign.id,
+                campaign.title,
+                campaign.description,
+                campaign.status,
+                campaign.scheduledAt,
+                JPAExpressions.select(campaignProduct.count().intValue())
+                    .from(campaignProduct)
+                    .where(campaignProduct.campaign.id.eq(campaign.id))))
+        .from(campaign)
+        .where(builder)
+        .orderBy(campaign.id.desc())
+        .limit(query.fetchSize())
+        .fetch();
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/persistence/CampaignQueryRepository.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/persistence/CampaignQueryRepository.java
@@ -6,7 +6,6 @@ import static org.giglab.live.commerce.core.campaign.domain.entity.QCampaignProd
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
@@ -50,11 +49,12 @@ public class CampaignQueryRepository {
                 campaign.description,
                 campaign.status,
                 campaign.scheduledAt,
-                JPAExpressions.select(campaignProduct.count().intValue())
-                    .from(campaignProduct)
-                    .where(campaignProduct.campaign.id.eq(campaign.id))))
+                campaignProduct.count().intValue()))
         .from(campaign)
+        .leftJoin(campaignProduct)
+        .on(campaignProduct.campaign.id.eq(campaign.id))
         .where(builder)
+        .groupBy(campaign.id)
         .orderBy(campaign.id.desc())
         .limit(query.fetchSize())
         .fetch();

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/persistence/CampaignQueryRepository.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/persistence/CampaignQueryRepository.java
@@ -5,12 +5,16 @@ import static org.giglab.live.commerce.core.campaign.domain.entity.QCampaignProd
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
+import org.giglab.live.commerce.core.campaign.application.dto.CampaignProductDto;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignSummary;
+import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
 import org.giglab.live.commerce.core.global.jpa.entity.types.YnType;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
@@ -54,5 +58,53 @@ public class CampaignQueryRepository {
         .orderBy(campaign.id.desc())
         .limit(query.fetchSize())
         .fetch();
+  }
+
+  public Optional<GetCampaignResult> findById(Long campaignId) {
+    var row =
+        queryFactory
+            .select(
+                campaign.id,
+                campaign.title,
+                campaign.description,
+                campaign.status,
+                campaign.scheduledAt,
+                campaign.startedAt,
+                campaign.endedAt)
+            .from(campaign)
+            .where(defaultCondition(), campaign.id.eq(campaignId))
+            .fetchOne();
+
+    if (row == null) {
+      return Optional.empty();
+    }
+
+    List<CampaignProductDto> products =
+        queryFactory
+            .select(
+                Projections.constructor(
+                    CampaignProductDto.class,
+                    campaignProduct.productId,
+                    campaignProduct.name,
+                    campaignProduct.displayOrder))
+            .from(campaignProduct)
+            .where(campaignProduct.campaign.id.eq(campaignId))
+            .orderBy(campaignProduct.displayOrder.asc())
+            .fetch();
+
+    return Optional.of(
+        new GetCampaignResult(
+            row.get(campaign.id),
+            row.get(campaign.title),
+            row.get(campaign.description),
+            row.get(campaign.status),
+            row.get(campaign.scheduledAt),
+            row.get(campaign.startedAt),
+            row.get(campaign.endedAt),
+            products));
+  }
+
+  private BooleanExpression defaultCondition() {
+    return campaign.deleteYn.eq(YnType.N);
   }
 }

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/persistence/CampaignRepository.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/persistence/CampaignRepository.java
@@ -1,0 +1,6 @@
+package org.giglab.live.commerce.core.campaign.infrastructure.persistence;
+
+import org.giglab.live.commerce.core.campaign.domain.entity.Campaign;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CampaignRepository extends JpaRepository<Campaign, Long> {}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/infrastructure/persistence/ProductQueryRepository.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/infrastructure/persistence/ProductQueryRepository.java
@@ -5,6 +5,7 @@ import static org.giglab.live.commerce.core.product.domain.entity.QProductCatego
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -25,7 +26,7 @@ public class ProductQueryRepository {
 
   public List<ProductSummary> findList(ProductListQuery query) {
     BooleanBuilder builder = new BooleanBuilder();
-    builder.and(product.deleteYn.eq(YnType.N));
+    builder.and(defaultCondition());
 
     if (query.cursor() != null) {
       builder.and(product.id.lt(query.cursor()));
@@ -60,9 +61,10 @@ public class ProductQueryRepository {
 
   public Optional<Product> findById(Long id) {
     return Optional.ofNullable(
-        queryFactory
-            .selectFrom(product)
-            .where(product.id.eq(id), product.deleteYn.eq(YnType.N))
-            .fetchOne());
+        queryFactory.selectFrom(product).where(defaultCondition(), product.id.eq(id)).fetchOne());
+  }
+
+  private BooleanExpression defaultCondition() {
+    return product.deleteYn.eq(YnType.N);
   }
 }

--- a/web-client/pages/broadcasts.tsx
+++ b/web-client/pages/broadcasts.tsx
@@ -1,52 +1,73 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
-type BroadcastStatus = 'scheduled' | 'live' | 'ended';
+const API_BASE = `${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8090'}/api/v1`;
 
-interface Broadcast {
-  id: string;
+interface Campaign {
+  id: number;
   title: string;
-  productName: string;
-  productId: string;
-  status: BroadcastStatus;
-  startedAt?: string;
+  description: string;
+  status: string;
+  scheduledAt: string;
+  productCount: number;
 }
 
-interface Product {
-  id: string;
-  name: string;
-  category: string;
-}
-
-const MOCK_PRODUCTS: Product[] = [
-  { id: 'P001', name: '워터프루프 립스틱', category: '뷰티' },
-  { id: 'P002', name: '비타민C 세럼', category: '스킨케어' },
-  { id: 'P003', name: '쿠션 파운데이션', category: '뷰티' },
-];
-
-const MOCK_BROADCASTS: Broadcast[] = [
-  { id: 'B001', title: '봄맞이 뷰티 라이브', productName: '워터프루프 립스틱', productId: 'P001', status: 'live', startedAt: '14:00' },
-  { id: 'B002', title: '스킨케어 집중 케어', productName: '비타민C 세럼', productId: 'P002', status: 'scheduled' },
-  { id: 'B003', title: '파운데이션 비교 테스트', productName: '쿠션 파운데이션', productId: 'P003', status: 'ended', startedAt: '10:00' },
-];
-
-const statusLabel: Record<BroadcastStatus, string> = {
-  scheduled: '예정',
-  live: '라이브 중',
-  ended: '종료',
+const statusLabel: Record<string, string> = {
+  SCHEDULED: '예정',
+  ON_AIR: '라이브 중',
+  ENDED: '종료',
 };
 
-const statusClass: Record<BroadcastStatus, string> = {
-  scheduled: 'status-scheduled',
-  live: 'status-live',
-  ended: 'status-ended',
+const statusClass: Record<string, string> = {
+  SCHEDULED: 'status-scheduled',
+  ON_AIR: 'status-live',
+  ENDED: 'status-ended',
 };
 
 export default function Broadcasts() {
   const router = useRouter();
-  const [broadcasts] = useState<Broadcast[]>(MOCK_BROADCASTS);
+  const [campaigns, setCampaigns] = useState<Campaign[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [nextCursor, setNextCursor] = useState<number | null>(null);
+  const [hasNext, setHasNext] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const fetchCampaigns = async (cursor?: number) => {
+    try {
+      const params = new URLSearchParams({ size: '20' });
+      if (cursor != null) params.set('cursor', String(cursor));
+      const res = await fetch(`${API_BASE}/campaigns?${params}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+      const { items, nextCursor: nc, hasNext: hn } = json.data;
+      setCampaigns((prev) => cursor != null ? [...prev, ...items] : items);
+      setNextCursor(nc ?? null);
+      setHasNext(hn);
+    } catch (err) {
+      setError('방송 목록을 불러오는 데 실패했습니다.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  };
+
+  useEffect(() => { fetchCampaigns(); }, []);
+
+  const handleLoadMore = () => {
+    if (nextCursor == null) return;
+    setLoadingMore(true);
+    fetchCampaigns(nextCursor);
+  };
+
+  const formatDate = (iso: string) => {
+    if (!iso) return '';
+    const d = new Date(iso);
+    return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+  };
 
   return (
     <>
@@ -72,10 +93,10 @@ export default function Broadcasts() {
         .card:hover { border-color: rgba(99,102,241,0.3); }
         .card.live { border-color: rgba(239,68,68,0.4); background: rgba(239,68,68,0.04); }
         .card-left { flex: 1; min-width: 0; }
-        .card-title { font-size: 18px; font-weight: 700; color: #f1f5f9; margin-bottom: 8px; }
+        .card-title { font-size: 18px; font-weight: 700; color: #f1f5f9; margin-bottom: 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
         .card-meta { display: flex; align-items: center; gap: 10px; font-size: 13px; color: #64748b; }
         .product-tag { background: rgba(99,102,241,0.12); border: 1px solid rgba(99,102,241,0.2); color: #a5b4fc; padding: 2px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; }
-        .started-at { font-size: 12px; }
+        .scheduled-at { font-size: 12px; }
         .card-right { display: flex; align-items: center; gap: 14px; flex-shrink: 0; }
         .status-badge { font-size: 12px; font-weight: 700; padding: 4px 12px; border-radius: 999px; }
         .status-live { background: rgba(239,68,68,0.15); color: #fca5a5; border: 1px solid rgba(239,68,68,0.3); }
@@ -87,6 +108,13 @@ export default function Broadcasts() {
         .btn-enter-live:hover { opacity: 0.85; }
         .btn-enter-normal { background: rgba(99,102,241,0.15); border: 1px solid rgba(99,102,241,0.3); color: #a5b4fc; }
         .btn-enter-normal:hover { background: rgba(99,102,241,0.25); }
+        .loading { text-align: center; padding: 60px; color: #475569; font-size: 14px; }
+        .error-msg { text-align: center; padding: 60px; color: #f87171; font-size: 14px; }
+        .empty { text-align: center; padding: 60px; color: #475569; font-size: 14px; }
+        .load-more { display: flex; justify-content: center; margin-top: 24px; }
+        .btn-more { padding: 10px 32px; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); color: #94a3b8; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; transition: background 0.2s; }
+        .btn-more:hover:not(:disabled) { background: rgba(255,255,255,0.1); }
+        .btn-more:disabled { opacity: 0.5; cursor: not-allowed; }
       `}</style>
 
       <div className="container">
@@ -99,9 +127,7 @@ export default function Broadcasts() {
         <div className="header">
           <h1 className="title">방송 목록</h1>
           <div className="header-actions">
-            <Link href="/products" className="btn-products">
-              상품 관리
-            </Link>
+            <Link href="/products" className="btn-products">상품 관리</Link>
             <button className="btn-add" onClick={() => router.push('/broadcasts/new')}>+ 방송 생성</button>
           </div>
         </div>
@@ -110,32 +136,48 @@ export default function Broadcasts() {
           <Link href="/products" className="rag-notice-link">상품 관리 →</Link>
         </div>
 
-        <div className="list">
-          {broadcasts.map((b) => (
-            <div key={b.id} className={`card ${b.status === 'live' ? 'live' : ''}`}>
-              <div className="card-left">
-                <div className="card-title">{b.title}</div>
-                <div className="card-meta">
-                  <span className="product-tag">📦 {b.productName}</span>
-                  {b.startedAt && <span className="started-at">시작 {b.startedAt}</span>}
+        {loading ? (
+          <div className="loading">불러오는 중...</div>
+        ) : error ? (
+          <div className="error-msg">{error}</div>
+        ) : campaigns.length === 0 ? (
+          <div className="empty">등록된 방송이 없습니다.</div>
+        ) : (
+          <>
+            <div className="list">
+              {campaigns.map((c) => (
+                <div key={c.id} className={`card ${c.status === 'ON_AIR' ? 'live' : ''}`}>
+                  <div className="card-left">
+                    <div className="card-title">{c.title}</div>
+                    <div className="card-meta">
+                      <span className="product-tag">📦 상품 {c.productCount}개</span>
+                      {c.scheduledAt && <span className="scheduled-at">예정 {formatDate(c.scheduledAt)}</span>}
+                    </div>
+                  </div>
+                  <div className="card-right">
+                    <span className={`status-badge ${statusClass[c.status] ?? 'status-ended'}`}>
+                      {statusLabel[c.status] ?? c.status}
+                    </span>
+                    <button
+                      className={`btn-enter ${c.status === 'ON_AIR' ? 'btn-enter-live' : 'btn-enter-normal'}`}
+                      onClick={() => router.push(`/broadcasts/${c.id}`)}
+                    >
+                      {c.status === 'ENDED' ? '다시보기' : '입장'}
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div className="card-right">
-                <span className={`status-badge ${statusClass[b.status]}`}>
-                  {statusLabel[b.status]}
-                </span>
-                <button
-                  className={`btn-enter ${b.status === 'live' ? 'btn-enter-live' : 'btn-enter-normal'}`}
-                  onClick={() => router.push(`/broadcasts/${b.id}`)}
-                >
-                  {b.status === 'ended' ? '다시보기' : '입장'}
+              ))}
+            </div>
+            {hasNext && (
+              <div className="load-more">
+                <button className="btn-more" onClick={handleLoadMore} disabled={loadingMore}>
+                  {loadingMore ? '불러오는 중...' : '더 보기'}
                 </button>
               </div>
-            </div>
-          ))}
-        </div>
+            )}
+          </>
+        )}
       </div>
-
     </>
   );
 }

--- a/web-client/pages/broadcasts/[id].tsx
+++ b/web-client/pages/broadcasts/[id].tsx
@@ -6,15 +6,27 @@ import { useRouter } from 'next/router';
 
 type BroadcastStatus = 'scheduled' | 'live' | 'ended';
 
-interface Broadcast {
-  id: string;
+interface CampaignProduct {
+  productId: number;
+  name: string;
+  displayOrder: number;
+}
+
+interface Campaign {
+  id: number;
   title: string;
-  productName: string;
-  productId: string;
-  status: BroadcastStatus;
-  startedAt?: string;
-  viewerCount?: number;
-  description?: string;
+  description: string;
+  status: string;
+  scheduledAt: string | null;
+  startedAt: string | null;
+  endedAt: string | null;
+  campaignProducts: CampaignProduct[];
+}
+
+function toUiStatus(apiStatus: string): BroadcastStatus {
+  if (apiStatus === 'ON_AIR') return 'live';
+  if (apiStatus === 'ENDED') return 'ended';
+  return 'scheduled';
 }
 
 interface Message {
@@ -32,43 +44,6 @@ interface QnAItem {
   timestamp: Date;
   isLoading?: boolean;
 }
-
-const MOCK_BROADCASTS: Broadcast[] = [
-  {
-    id: 'B001',
-    title: '봄맞이 뷰티 라이브',
-    productName: '워터프루프 립스틱',
-    productId: 'P001',
-    status: 'live',
-    startedAt: '14:00',
-    viewerCount: 1243,
-    description: '봄 시즌 신상 립스틱을 직접 발색해보는 라이브입니다. 다양한 컬러와 지속력을 확인해보세요!',
-  },
-  {
-    id: 'B002',
-    title: '스킨케어 집중 케어',
-    productName: '비타민C 세럼',
-    productId: 'P002',
-    status: 'scheduled',
-    description: '피부 고민을 한 번에 해결해줄 비타민C 세럼 소개 라이브입니다.',
-  },
-  {
-    id: 'B003',
-    title: '파운데이션 비교 테스트',
-    productName: '쿠션 파운데이션',
-    productId: 'P003',
-    status: 'ended',
-    startedAt: '10:00',
-    viewerCount: 3892,
-    description: '인기 쿠션 파운데이션 5종을 직접 비교해보는 방송입니다.',
-  },
-];
-
-const MOCK_PRODUCTS = [
-  { id: 'P001', name: '워터프루프 립스틱', category: '뷰티', price: 25000, embeddingStatus: 'done' },
-  { id: 'P002', name: '비타민C 세럼', category: '스킨케어', price: 48000, embeddingStatus: 'done' },
-  { id: 'P003', name: '쿠션 파운데이션', category: '뷰티', price: 35000, embeddingStatus: 'none' },
-];
 
 // Mock AI 응답
 const MOCK_AI_ANSWERS: Record<string, string> = {
@@ -489,26 +464,28 @@ function EndedAnalysisPanel() {
 }
 
 // ─── 메인 페이지 ─────────────────────────────────────────────────────
+const API_BASE = `${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8090'}/api/v1`;
+
 export default function BroadcastDetail() {
   const router = useRouter();
   const { id } = router.query;
 
-  const broadcast = MOCK_BROADCASTS.find((b) => b.id === id) ?? null;
+  const [campaign, setCampaign] = useState<Campaign | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputValue, setInputValue] = useState('');
   const [nickname, setNickname] = useState('시청자');
   const [wsConnected, setWsConnected] = useState(false);
   const [areScriptsReady, setAreScriptsReady] = useState(false);
-  const [viewerCount, setViewerCount] = useState(broadcast?.viewerCount ?? 0);
-  const [linkedProductIds, setLinkedProductIds] = useState<string[]>(
-    broadcast?.productId ? [broadcast.productId] : []
-  );
+  const [viewerCount, setViewerCount] = useState(0);
+  const [linkedProductIds, setLinkedProductIds] = useState<number[]>([]);
   const [showProductPicker, setShowProductPicker] = useState(false);
 
-  const toggleProduct = (id: string) => {
+  const toggleProduct = (pid: number) => {
     setLinkedProductIds((prev) =>
-      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+      prev.includes(pid) ? prev.filter((x) => x !== pid) : [...prev, pid]
     );
   };
 
@@ -520,12 +497,30 @@ export default function BroadcastDetail() {
   const WS_BASE_URL = process.env.NEXT_PUBLIC_WS_URL || API_BASE_URL;
 
   useEffect(() => {
-    if (broadcast?.status !== 'live') return;
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+    fetch(`${API_BASE}/campaigns/${id}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((json) => {
+        const data: Campaign = json.data;
+        setCampaign(data);
+        setLinkedProductIds(data.campaignProducts.map((p) => p.productId));
+      })
+      .catch(() => setError('캠페인 정보를 불러오는 데 실패했습니다.'))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  useEffect(() => {
+    if (!campaign || toUiStatus(campaign.status) !== 'live') return;
     const interval = setInterval(() => {
       setViewerCount((prev) => Math.max(1, prev + Math.floor(Math.random() * 20) - 8));
     }, 3000);
     return () => clearInterval(interval);
-  }, [broadcast?.status]);
+  }, [campaign?.status]);
 
   const markScriptsReady = () => {
     if (typeof window === 'undefined') return;
@@ -594,7 +589,20 @@ export default function BroadcastDetail() {
 
   if (!id) return null;
 
-  if (!broadcast) {
+  if (loading) {
+    return (
+      <>
+        <Head><title>로딩 중...</title></Head>
+        <style jsx global>{`* { margin:0;padding:0;box-sizing:border-box; } body { font-family: -apple-system,sans-serif; background:#0f172a; color:#e2e8f0; min-height:100vh; } a { text-decoration:none;color:inherit; }`}</style>
+        <div style={{ maxWidth: 600, margin: '0 auto', padding: '80px 24px', textAlign: 'center' }}>
+          <div style={{ fontSize: 48, marginBottom: 20 }}>⏳</div>
+          <p style={{ color: '#64748b' }}>방송 정보를 불러오는 중...</p>
+        </div>
+      </>
+    );
+  }
+
+  if (error || !campaign) {
     return (
       <>
         <Head><title>방송을 찾을 수 없음</title></Head>
@@ -602,7 +610,7 @@ export default function BroadcastDetail() {
         <div style={{ maxWidth: 600, margin: '0 auto', padding: '80px 24px', textAlign: 'center' }}>
           <div style={{ fontSize: 48, marginBottom: 20 }}>📡</div>
           <h1 style={{ fontSize: 24, fontWeight: 700, color: '#f1f5f9', marginBottom: 12 }}>방송을 찾을 수 없습니다</h1>
-          <p style={{ color: '#64748b', marginBottom: 32 }}>요청하신 방송이 존재하지 않거나 삭제되었습니다.</p>
+          <p style={{ color: '#64748b', marginBottom: 32 }}>{error ?? '요청하신 방송이 존재하지 않거나 삭제되었습니다.'}</p>
           <Link href="/broadcasts" style={{ padding: '10px 24px', background: 'linear-gradient(135deg,#6366f1,#8b5cf6)', color: 'white', borderRadius: 8, fontSize: 14, fontWeight: 600 }}>
             목록으로 돌아가기
           </Link>
@@ -611,12 +619,17 @@ export default function BroadcastDetail() {
     );
   }
 
-  const isLive = broadcast.status === 'live';
-  const isScheduled = broadcast.status === 'scheduled';
+  const uiStatus = toUiStatus(campaign.status);
+  const isLive = uiStatus === 'live';
+  const isScheduled = uiStatus === 'scheduled';
+  const productName = campaign.campaignProducts[0]?.name ?? '상품 없음';
+  const startedAtLabel = campaign.startedAt
+    ? new Date(campaign.startedAt).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
+    : null;
 
   return (
     <>
-      <Head><title>{broadcast.title} — Live Platform Lab</title></Head>
+      <Head><title>{campaign.title} — Live Platform Lab</title></Head>
       <Script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js" strategy="afterInteractive" onLoad={markScriptsReady} />
       <Script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7/bundles/stomp.umd.min.js" strategy="afterInteractive" onLoad={markScriptsReady} />
 
@@ -650,7 +663,6 @@ export default function BroadcastDetail() {
         .info-card { background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); border-radius:14px; padding:24px; }
         .info-title { font-size:22px; font-weight:700; color:#f1f5f9; margin-bottom:12px; }
         .info-meta { display:flex; flex-wrap:wrap; align-items:center; gap:10px; margin-bottom:14px; }
-        .product-tag { background:rgba(99,102,241,0.12); border:1px solid rgba(99,102,241,0.2); color:#a5b4fc; padding:4px 12px; border-radius:999px; font-size:13px; font-weight:600; }
         .s-badge { font-size:12px; font-weight:700; padding:4px 12px; border-radius:999px; }
         .s-live { background:rgba(239,68,68,0.15); color:#fca5a5; border:1px solid rgba(239,68,68,0.3); }
         .s-scheduled { background:rgba(251,191,36,0.12); color:#fcd34d; border:1px solid rgba(251,191,36,0.25); }
@@ -668,8 +680,7 @@ export default function BroadcastDetail() {
         .product-match-card { display:flex; align-items:center; justify-content:space-between; gap:12px; padding:10px 14px; background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); border-radius:10px; }
         .product-match-info { display:flex; align-items:center; gap:10px; flex-wrap:wrap; flex:1; min-width:0; }
         .product-match-name { font-size:13px; font-weight:700; color:#f1f5f9; }
-        .product-match-cat { font-size:11px; font-weight:600; padding:2px 8px; border-radius:999px; background:rgba(99,102,241,0.12); color:#a5b4fc; border:1px solid rgba(99,102,241,0.2); }
-        .product-match-price { font-size:12px; color:#64748b; }
+        .product-match-order { font-size:11px; font-weight:600; padding:2px 8px; border-radius:999px; background:rgba(99,102,241,0.12); color:#a5b4fc; border:1px solid rgba(99,102,241,0.2); }
         .btn-remove-product { background:none; border:none; color:#475569; font-size:13px; cursor:pointer; padding:2px 4px; flex-shrink:0; line-height:1; }
         .btn-remove-product:hover { color:#f87171; }
         .product-match-empty { font-size:13px; color:#475569; padding:6px 0; }
@@ -679,9 +690,7 @@ export default function BroadcastDetail() {
         .picker-item.selected { background:rgba(99,102,241,0.1); }
         .picker-item-left { display:flex; align-items:center; gap:8px; }
         .picker-item-name { font-size:13px; font-weight:600; color:#e2e8f0; }
-        .picker-item-cat { font-size:11px; color:#64748b; }
-        .picker-item-right { display:flex; align-items:center; gap:8px; }
-        .picker-item-price { font-size:12px; color:#64748b; }
+        .picker-item-order { font-size:11px; color:#64748b; }
         .picker-check { font-size:12px; font-weight:700; color:#475569; width:16px; text-align:center; }
         .picker-check.on { color:#6366f1; }
 
@@ -700,7 +709,7 @@ export default function BroadcastDetail() {
             <span className="nav-sep">/</span>
             <Link href="/broadcasts">방송 목록</Link>
             <span className="nav-sep">/</span>
-            <span className="nav-cur">{broadcast.title}</span>
+            <span className="nav-cur">{campaign.title}</span>
           </nav>
         </div>
 
@@ -724,24 +733,23 @@ export default function BroadcastDetail() {
                 </>
               )}
               {isScheduled && <div className="status-overlay scheduled">🕐 방송 예정</div>}
-              {broadcast.status === 'ended' && (
+              {uiStatus === 'ended' && (
                 <div className="status-overlay ended">
-                  종료{broadcast.startedAt && ` · ${broadcast.startedAt} 시작`}
-                  {broadcast.viewerCount && ` · ${broadcast.viewerCount.toLocaleString()}명 시청`}
+                  종료{startedAtLabel && ` · ${startedAtLabel} 시작`}
                 </div>
               )}
             </div>
 
             {/* 방송 정보 */}
             <div className="info-card">
-              <h1 className="info-title">{broadcast.title}</h1>
+              <h1 className="info-title">{campaign.title}</h1>
               <div className="info-meta">
-                <span className={`s-badge s-${broadcast.status}`}>
-                  {isLive && '● '}{statusLabel[broadcast.status]}
+                <span className={`s-badge s-${uiStatus}`}>
+                  {isLive && '● '}{statusLabel[uiStatus]}
                 </span>
-                {broadcast.startedAt && <span className="info-started">시작 {broadcast.startedAt}</span>}
+                {startedAtLabel && <span className="info-started">시작 {startedAtLabel}</span>}
               </div>
-              {broadcast.description && <p className="info-desc">{broadcast.description}</p>}
+              {campaign.description && <p className="info-desc">{campaign.description}</p>}
 
               {/* 상품 매칭 */}
               <div className="product-match-section">
@@ -749,7 +757,7 @@ export default function BroadcastDetail() {
                   <span className="product-match-label">
                     연결된 상품 {linkedProductIds.length > 0 && <span className="product-count">{linkedProductIds.length}</span>}
                   </span>
-                  {broadcast.status !== 'ended' && (
+                  {uiStatus !== 'ended' && (
                     <button className="btn-change-product" onClick={() => setShowProductPicker((v) => !v)}>
                       {showProductPicker ? '닫기' : '+ 상품 추가'}
                     </button>
@@ -761,16 +769,15 @@ export default function BroadcastDetail() {
                 ) : (
                   <div className="product-match-list">
                     {linkedProductIds.map((pid) => {
-                      const p = MOCK_PRODUCTS.find((x) => x.id === pid);
+                      const p = campaign.campaignProducts.find((x) => x.productId === pid);
                       if (!p) return null;
                       return (
                         <div key={pid} className="product-match-card">
                           <div className="product-match-info">
                             <span className="product-match-name">{p.name}</span>
-                            <span className="product-match-cat">{p.category}</span>
-                            <span className="product-match-price">{p.price.toLocaleString()}원</span>
+                            <span className="product-match-order">#{p.displayOrder}</span>
                           </div>
-                          {broadcast.status !== 'ended' && (
+                          {uiStatus !== 'ended' && (
                             <button className="btn-remove-product" onClick={() => toggleProduct(pid)}>✕</button>
                           )}
                         </div>
@@ -779,22 +786,21 @@ export default function BroadcastDetail() {
                   </div>
                 )}
 
-                {broadcast.status !== 'ended' && showProductPicker && (
+                {uiStatus !== 'ended' && showProductPicker && (
                   <div className="product-picker">
-                    {MOCK_PRODUCTS.map((p) => {
-                      const isLinked = linkedProductIds.includes(p.id);
+                    {campaign.campaignProducts.map((p) => {
+                      const isLinked = linkedProductIds.includes(p.productId);
                       return (
                         <div
-                          key={p.id}
+                          key={p.productId}
                           className={`picker-item ${isLinked ? 'selected' : ''}`}
-                          onClick={() => toggleProduct(p.id)}
+                          onClick={() => toggleProduct(p.productId)}
                         >
                           <div className="picker-item-left">
                             <span className="picker-item-name">{p.name}</span>
-                            <span className="picker-item-cat">{p.category}</span>
+                            <span className="picker-item-order">순서 {p.displayOrder}</span>
                           </div>
                           <div className="picker-item-right">
-                            <span className="picker-item-price">{p.price.toLocaleString()}원</span>
                             <span className={`picker-check ${isLinked ? 'on' : ''}`}>{isLinked ? '✓' : '+'}</span>
                           </div>
                         </div>
@@ -810,8 +816,8 @@ export default function BroadcastDetail() {
           <div className="side-col">
             {(isScheduled || isLive) && (
               <ChatQnAPanel
-                status={broadcast.status}
-                productName={broadcast.productName}
+                status={uiStatus}
+                productName={productName}
                 messages={messages}
                 inputValue={inputValue}
                 setInputValue={setInputValue}
@@ -823,7 +829,7 @@ export default function BroadcastDetail() {
                 areScriptsReady={areScriptsReady}
               />
             )}
-            {broadcast.status === 'ended' && <EndedAnalysisPanel />}
+            {uiStatus === 'ended' && <EndedAnalysisPanel />}
           </div>
         </div>
       </div>

--- a/web-client/pages/broadcasts/new.tsx
+++ b/web-client/pages/broadcasts/new.tsx
@@ -1,32 +1,56 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
-interface Product {
-  id: string;
-  name: string;
-  category: string;
-  price: number;
-  description: string;
-  embeddingStatus: 'none' | 'pending' | 'done';
-}
+const API_BASE = `${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8090'}/api/v1`;
 
-const MOCK_PRODUCTS: Product[] = [
-  { id: 'P001', name: '워터프루프 립스틱', category: '뷰티', price: 25000, description: '24시간 지속되는 방수 립스틱. 선명한 발색과 촉촉한 보습력을 동시에.', embeddingStatus: 'done' },
-  { id: 'P002', name: '비타민C 세럼', category: '스킨케어', price: 48000, description: '고농도 비타민C 15% 함유. 미백과 탄력 개선에 효과적입니다.', embeddingStatus: 'done' },
-  { id: 'P003', name: '쿠션 파운데이션', category: '뷰티', price: 35000, description: 'SPF50+ PA++++ 자외선 차단. 촉촉한 피부 표현에 최적화된 쿠션.', embeddingStatus: 'none' },
-];
+interface Product {
+  id: number;
+  name: string;
+  status: string;
+  price: number;
+  categoryName?: string;
+}
 
 export default function BroadcastNew() {
   const router = useRouter();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [scheduledAt, setScheduledAt] = useState('');
-  const [selectedProductIds, setSelectedProductIds] = useState<string[]>([]);
+  const [selectedProductIds, setSelectedProductIds] = useState<number[]>([]);
   const [showProductPicker, setShowProductPicker] = useState(false);
-  const [errors, setErrors] = useState<{ title?: string; product?: string }>({});
+  const [errors, setErrors] = useState<{ title?: string; product?: string; submit?: string }>({});
   const [isSaving, setIsSaving] = useState(false);
+
+  const [products, setProducts] = useState<Product[]>([]);
+  const [productsLoading, setProductsLoading] = useState(false);
+  const [productKeyword, setProductKeyword] = useState('');
+
+  const fetchProducts = (keyword: string) => {
+    setProductsLoading(true);
+    const params = new URLSearchParams({ size: '20' });
+    if (keyword.trim()) params.set('keyword', keyword.trim());
+    fetch(`${API_BASE}/products?${params}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((json) => setProducts(json.data?.items ?? []))
+      .catch((err) => console.error('[상품 조회 실패]', err))
+      .finally(() => setProductsLoading(false));
+  };
+
+  useEffect(() => {
+    if (!showProductPicker) return;
+    fetchProducts(productKeyword);
+  }, [showProductPicker]);
+
+  useEffect(() => {
+    if (!showProductPicker) return;
+    const timer = setTimeout(() => fetchProducts(productKeyword), 300);
+    return () => clearTimeout(timer);
+  }, [productKeyword]);
 
   const validate = () => {
     const errs: { title?: string; product?: string } = {};
@@ -39,12 +63,30 @@ export default function BroadcastNew() {
     const errs = validate();
     if (Object.keys(errs).length > 0) { setErrors(errs); return; }
     setIsSaving(true);
-    // TODO: POST /api/v1/broadcasts
-    await new Promise((r) => setTimeout(r, 700));
-    router.push('/broadcasts');
+    setErrors((prev) => ({ ...prev, submit: undefined }));
+    try {
+      const res = await fetch(`${API_BASE}/campaigns`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title,
+          description,
+          scheduledAt: scheduledAt ? new Date(scheduledAt).toISOString().slice(0, 19) : new Date().toISOString().slice(0, 19),
+          campaignProducts: selectedProductIds.map((id, idx) => ({ productId: id, displayOrder: idx + 1 })),
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.message ?? `등록 실패 (${res.status})`);
+      }
+      router.push('/broadcasts');
+    } catch (err) {
+      setErrors((prev) => ({ ...prev, submit: err instanceof Error ? err.message : '등록 중 오류가 발생했습니다.' }));
+      setIsSaving(false);
+    }
   };
 
-  const toggleProduct = (id: string) => {
+  const toggleProduct = (id: number) => {
     setSelectedProductIds((prev) =>
       prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
     );
@@ -103,6 +145,9 @@ export default function BroadcastNew() {
         .btn-remove-product:hover { color: #f87171; background: rgba(239,68,68,0.1); }
         .product-empty { font-size: 13px; color: #475569; margin-bottom: 12px; }
 
+        .product-search { width: 100%; padding: 9px 12px; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); border-radius: 8px; font-size: 13px; color: #f1f5f9; outline: none; font-family: inherit; margin-bottom: 6px; }
+        .product-search:focus { border-color: #6366f1; }
+        .product-search::placeholder { color: #334155; }
         .product-picker { display: flex; flex-direction: column; gap: 4px; padding: 8px; background: rgba(0,0,0,0.25); border: 1px solid rgba(255,255,255,0.08); border-radius: 10px; }
         .picker-item { display: flex; align-items: center; justify-content: space-between; padding: 9px 12px; border-radius: 8px; cursor: pointer; transition: background 0.15s; }
         .picker-item:hover { background: rgba(255,255,255,0.04); }
@@ -134,7 +179,8 @@ export default function BroadcastNew() {
         <div className="page-header">
           <h1 className="page-title">방송 등록</h1>
           <div className="header-actions">
-            <Link href="/broadcasts" className="btn-cancel">취소</Link>
+            {errors.submit && <span style={{ fontSize: '12px', color: '#f87171', alignSelf: 'center' }}>{errors.submit}</span>}
+            <Link href="/broadcasts" className="btn-cancel" style={{ marginTop: '8px'}}>취소</Link>
             <button className="btn-save" onClick={handleSave} disabled={isSaving}>
               {isSaving ? '저장 중...' : '저장'}
             </button>
@@ -196,13 +242,13 @@ export default function BroadcastNew() {
             ) : (
               <div className="product-list">
                 {selectedProductIds.map((pid) => {
-                  const p = MOCK_PRODUCTS.find((x) => x.id === pid);
+                  const p = products.find((x) => x.id === pid);
                   if (!p) return null;
                   return (
                     <div key={pid} className="product-list-card">
                       <div className="product-list-info">
                         <span className="product-list-name">{p.name}</span>
-                        <span className="product-list-cat">{p.category}</span>
+                        {p.categoryName && <span className="product-list-cat">{p.categoryName}</span>}
                         <span className="product-list-price">{p.price.toLocaleString()}원</span>
                       </div>
                       <button className="btn-remove-product" onClick={() => toggleProduct(pid)}>✕</button>
@@ -213,8 +259,19 @@ export default function BroadcastNew() {
             )}
 
             {showProductPicker && (
+              <>
+                <input
+                  className="product-search"
+                  placeholder="상품명으로 검색..."
+                  value={productKeyword}
+                  onChange={(e) => setProductKeyword(e.target.value)}
+                />
               <div className="product-picker">
-                {MOCK_PRODUCTS.map((p) => {
+                {productsLoading ? (
+                  <div style={{ padding: '16px', fontSize: '13px', color: '#475569', textAlign: 'center' }}>검색 중...</div>
+                ) : products.length === 0 ? (
+                  <div style={{ padding: '16px', fontSize: '13px', color: '#475569', textAlign: 'center' }}>검색 결과가 없습니다.</div>
+                ) : products.map((p) => {
                   const isSelected = selectedProductIds.includes(p.id);
                   return (
                     <div
@@ -224,7 +281,7 @@ export default function BroadcastNew() {
                     >
                       <div className="picker-item-left">
                         <span className="picker-item-name">{p.name}</span>
-                        <span className="picker-item-cat">{p.category}</span>
+                        {p.categoryName && <span className="picker-item-cat">{p.categoryName}</span>}
                       </div>
                       <div className="picker-item-right">
                         <span className="picker-item-price">{p.price.toLocaleString()}원</span>
@@ -234,6 +291,7 @@ export default function BroadcastNew() {
                   );
                 })}
               </div>
+              </>
             )}
 
             {errors.product && <div className="error-msg">{errors.product}</div>}

--- a/web-client/pages/broadcasts/new.tsx
+++ b/web-client/pages/broadcasts/new.tsx
@@ -72,7 +72,10 @@ export default function BroadcastNew() {
           title,
           description,
           scheduledAt: scheduledAt ? new Date(scheduledAt).toISOString().slice(0, 19) : new Date().toISOString().slice(0, 19),
-          campaignProducts: selectedProductIds.map((id, idx) => ({ productId: id, displayOrder: idx + 1 })),
+          campaignProducts: selectedProductIds.map((id, idx) => {
+            const product = products.find((p) => p.id === id);
+            return { productId: id, name: product?.name ?? '', displayOrder: idx + 1 };
+          }),
         }),
       });
       if (!res.ok) {


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
캠페인(방송) 도메인의 생성·목록 조회·상세 조회 API를 구현하고, web-client의 broadcasts 페이지와 연동합니다.


### Issue
- closes #47


### Why
- 라이브 커머스 핵심 도메인인 캠페인의 CRUD 기반 기능이 필요합니다.
- 방송 목록·상세 페이지를 실제 API와 연결하여 mock 데이터를 제거합니다.


### What
- **캠페인 도메인 엔티티 구성**: `Campaign`, `CampaignProduct`, `BroadcastStatusType`
- **캠페인 생성 API**: `POST /api/v1/campaigns`
- **캠페인 목록 조회 API**: `GET /api/v1/campaigns` (커서 기반 페이지네이션)
- **캠페인 상세 조회 API**: `GET /api/v1/campaigns/{campaignId}`
- **web-client 연동**: `broadcasts.tsx`, `broadcasts/[id].tsx`, `broadcasts/new.tsx` mock 데이터 → 실제 API 호출로 교체


### How
- 헥사고날 아키텍처(UseCase / Port / Adapter) 패턴으로 계층을 분리합니다.
- QueryDSL을 사용해 캠페인 목록·상세를 조회합니다.
  - 상세 조회 시 캠페인 기본 정보와 상품 목록을 **2-step 쿼리**로 분리하여 QueryDSL의 `List<>` 생성자 매핑 제한을 회피합니다.
- web-client는 native `fetch()`로 API를 호출하며, API 상태값(`SCHEDULED`, `ON_AIR`, `ENDED`)을 UI 상태값(`scheduled`, `live`, `ended`)으로 변환합니다.


### Test
- 서버 실행 후 아래 엔드포인트를 순서대로 확인합니다.
  1. `POST /api/v1/campaigns` — 캠페인 생성
  2. `GET /api/v1/campaigns` — 목록 조회 (커서 페이지네이션)
  3. `GET /api/v1/campaigns/{id}` — 상세 조회 (campaignProducts 포함 여부 확인)
- web-client에서 `/broadcasts` 목록 페이지 → 상세 페이지 진입 후 API 데이터 정상 렌더링 확인