### PR TITLE
[#53] feat: 상품 상세에서 연결된 방송 조회 기능 구현

### DIFF
--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/controller/product/ProductController.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/controller/product/ProductController.java
@@ -12,6 +12,7 @@ import org.giglab.live.commerce.api.dto.product.EmbedAllDocumentsResponse;
 import org.giglab.live.commerce.api.dto.product.EmbedDocumentResponse;
 import org.giglab.live.commerce.api.dto.product.EmbedProductInfoResponse;
 import org.giglab.live.commerce.api.dto.product.GetDocumentListResponse;
+import org.giglab.live.commerce.api.dto.product.GetProductLinkedCampaignsResponse;
 import org.giglab.live.commerce.api.dto.product.GetProductListRequest;
 import org.giglab.live.commerce.api.dto.product.GetProductListResponse;
 import org.giglab.live.commerce.api.dto.product.GetProductResponse;
@@ -57,6 +58,14 @@ public class ProductController {
   public ResponseEntity<ApiResponse<CreateProductResponse>> create(
       @RequestBody @Valid CreateProductRequest createProductRequest) {
     CreateProductResponse response = productFacade.create(createProductRequest);
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+  @Operation(summary = "상품에 편성된 방송 목록 조회", description = "상품이 편성된 방송(Campaign) 목록을 조회합니다.")
+  @GetMapping("/{id}/campaigns")
+  public ResponseEntity<ApiResponse<GetProductLinkedCampaignsResponse>> getLinkedCampaigns(
+      @PathVariable Long id) {
+    GetProductLinkedCampaignsResponse response = productFacade.getLinkedCampaigns(id);
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/product/GetProductLinkedCampaignsResponse.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/product/GetProductLinkedCampaignsResponse.java
@@ -1,0 +1,5 @@
+package org.giglab.live.commerce.api.dto.product;
+
+import java.util.List;
+
+public record GetProductLinkedCampaignsResponse(List<LinkedCampaignItem> campaigns) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/product/LinkedCampaignItem.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/product/LinkedCampaignItem.java
@@ -1,0 +1,11 @@
+package org.giglab.live.commerce.api.dto.product;
+
+import java.time.LocalDateTime;
+
+public record LinkedCampaignItem(
+    Long campaignId,
+    String title,
+    String status,
+    LocalDateTime scheduledAt,
+    LocalDateTime startedAt,
+    LocalDateTime endedAt) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/facade/ProductFacade.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/facade/ProductFacade.java
@@ -11,6 +11,7 @@ import org.giglab.live.commerce.api.dto.product.EmbedAllDocumentsResponse;
 import org.giglab.live.commerce.api.dto.product.EmbedDocumentResponse;
 import org.giglab.live.commerce.api.dto.product.EmbedProductInfoResponse;
 import org.giglab.live.commerce.api.dto.product.GetDocumentListResponse;
+import org.giglab.live.commerce.api.dto.product.GetProductLinkedCampaignsResponse;
 import org.giglab.live.commerce.api.dto.product.GetProductListRequest;
 import org.giglab.live.commerce.api.dto.product.GetProductListResponse;
 import org.giglab.live.commerce.api.dto.product.GetProductResponse;
@@ -19,6 +20,7 @@ import org.giglab.live.commerce.api.mapper.product.ProductMapper;
 import org.giglab.live.commerce.core.product.application.ProductService;
 import org.giglab.live.commerce.core.product.application.dto.CreateProductCommand;
 import org.giglab.live.commerce.core.product.application.dto.CreateProductResult;
+import org.giglab.live.commerce.core.product.application.dto.GetProductLinkedCampaignsResult;
 import org.giglab.live.commerce.core.product.application.dto.GetProductListResult;
 import org.giglab.live.commerce.core.product.application.dto.GetProductResult;
 import org.giglab.live.commerce.core.product.application.dto.ProductListQuery;
@@ -54,6 +56,11 @@ public class ProductFacade {
   public GetProductResponse getDetail(Long id) {
     GetProductResult result = productService.getDetail(id);
     return productMapper.toGetProductResponse(result);
+  }
+
+  public GetProductLinkedCampaignsResponse getLinkedCampaigns(Long productId) {
+    GetProductLinkedCampaignsResult result = productService.getLinkedCampaigns(productId);
+    return productMapper.toGetProductLinkedCampaignsResponse(result);
   }
 
   public GetDocumentListResponse getDocumentList(Long productId) {

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/mapper/product/ProductMapper.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/mapper/product/ProductMapper.java
@@ -8,13 +8,17 @@ import org.giglab.live.commerce.api.dto.product.EmbedAllDocumentsResponse;
 import org.giglab.live.commerce.api.dto.product.EmbedDocumentResponse;
 import org.giglab.live.commerce.api.dto.product.EmbedProductInfoResponse;
 import org.giglab.live.commerce.api.dto.product.GetDocumentListResponse;
+import org.giglab.live.commerce.api.dto.product.GetProductLinkedCampaignsResponse;
 import org.giglab.live.commerce.api.dto.product.GetProductListRequest;
 import org.giglab.live.commerce.api.dto.product.GetProductListResponse;
 import org.giglab.live.commerce.api.dto.product.GetProductResponse;
+import org.giglab.live.commerce.api.dto.product.LinkedCampaignItem;
 import org.giglab.live.commerce.api.dto.product.ParsedProductResponse;
 import org.giglab.live.commerce.api.dto.product.ProductSummaryItem;
+import org.giglab.live.commerce.core.campaign.application.dto.ProductLinkedCampaignDto;
 import org.giglab.live.commerce.core.product.application.dto.CreateProductCommand;
 import org.giglab.live.commerce.core.product.application.dto.CreateProductResult;
+import org.giglab.live.commerce.core.product.application.dto.GetProductLinkedCampaignsResult;
 import org.giglab.live.commerce.core.product.application.dto.GetProductListResult;
 import org.giglab.live.commerce.core.product.application.dto.GetProductResult;
 import org.giglab.live.commerce.core.product.application.dto.ProductListQuery;
@@ -66,4 +70,10 @@ public interface ProductMapper {
   EmbedProductInfoResponse toEmbedProductInfoResponse(EmbedProductInfoResult result);
 
   EmbedAllDocumentsResponse toEmbedAllDocumentsResponse(EmbedAllDocumentsResult result);
+
+  @Mapping(target = "status", expression = "java(dto.status().name())")
+  LinkedCampaignItem toLinkedCampaignItem(ProductLinkedCampaignDto dto);
+
+  GetProductLinkedCampaignsResponse toGetProductLinkedCampaignsResponse(
+      GetProductLinkedCampaignsResult result);
 }

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/mapper/product/ProductMapper.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/mapper/product/ProductMapper.java
@@ -15,7 +15,6 @@ import org.giglab.live.commerce.api.dto.product.GetProductResponse;
 import org.giglab.live.commerce.api.dto.product.LinkedCampaignItem;
 import org.giglab.live.commerce.api.dto.product.ParsedProductResponse;
 import org.giglab.live.commerce.api.dto.product.ProductSummaryItem;
-import org.giglab.live.commerce.core.campaign.application.dto.ProductLinkedCampaignDto;
 import org.giglab.live.commerce.core.product.application.dto.CreateProductCommand;
 import org.giglab.live.commerce.core.product.application.dto.CreateProductResult;
 import org.giglab.live.commerce.core.product.application.dto.GetProductLinkedCampaignsResult;
@@ -30,6 +29,7 @@ import org.giglab.live.commerce.core.product.application.dto.pdf.DocumentSummary
 import org.giglab.live.commerce.core.product.application.dto.pdf.EmbedDocumentResult;
 import org.giglab.live.commerce.core.product.application.dto.pdf.GetDocumentListResult;
 import org.giglab.live.commerce.core.product.application.dto.pdf.ParsedProductResult;
+import org.giglab.live.commerce.core.shared.ProductLinkedCampaignDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/bridge/ProductCampaignBridge.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/bridge/ProductCampaignBridge.java
@@ -1,0 +1,22 @@
+package org.giglab.live.commerce.core.campaign.application.bridge;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.core.campaign.application.port.persistence.CampaignQueryPort;
+import org.giglab.live.commerce.core.product.application.port.bridge.ProductCampaignAppPort;
+import org.giglab.live.commerce.core.shared.ProductLinkedCampaignDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProductCampaignBridge implements ProductCampaignAppPort {
+
+  private final CampaignQueryPort campaignQueryPort;
+
+  @Override
+  public List<ProductLinkedCampaignDto> getLinkedCampaignList(Long productId) {
+    return campaignQueryPort.findByProductId(productId);
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/ProductLinkedCampaignDto.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/ProductLinkedCampaignDto.java
@@ -1,0 +1,12 @@
+package org.giglab.live.commerce.core.campaign.application.dto;
+
+import java.time.LocalDateTime;
+import org.giglab.live.commerce.core.campaign.domain.entity.types.BroadcastStatusType;
+
+public record ProductLinkedCampaignDto(
+    Long campaignId,
+    String title,
+    BroadcastStatusType status,
+    LocalDateTime scheduledAt,
+    LocalDateTime startedAt,
+    LocalDateTime endedAt) {}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/port/persistence/CampaignQueryPort.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/port/persistence/CampaignQueryPort.java
@@ -5,9 +5,12 @@ import java.util.Optional;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignSummary;
 import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
+import org.giglab.live.commerce.core.campaign.application.dto.ProductLinkedCampaignDto;
 
 public interface CampaignQueryPort {
   List<CampaignSummary> findList(CampaignListQuery query);
 
   Optional<GetCampaignResult> findById(Long campaignId);
+
+  List<ProductLinkedCampaignDto> findByProductId(Long productId);
 }

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/port/persistence/CampaignQueryPort.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/port/persistence/CampaignQueryPort.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignSummary;
 import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
-import org.giglab.live.commerce.core.campaign.application.dto.ProductLinkedCampaignDto;
+import org.giglab.live.commerce.core.shared.ProductLinkedCampaignDto;
 
 public interface CampaignQueryPort {
   List<CampaignSummary> findList(CampaignListQuery query);

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/adapter/JpaCampaignQueryAdapter.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/adapter/JpaCampaignQueryAdapter.java
@@ -6,9 +6,9 @@ import lombok.RequiredArgsConstructor;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignSummary;
 import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
-import org.giglab.live.commerce.core.campaign.application.dto.ProductLinkedCampaignDto;
 import org.giglab.live.commerce.core.campaign.application.port.persistence.CampaignQueryPort;
 import org.giglab.live.commerce.core.campaign.infrastructure.persistence.CampaignQueryRepository;
+import org.giglab.live.commerce.core.shared.ProductLinkedCampaignDto;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/adapter/JpaCampaignQueryAdapter.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/adapter/JpaCampaignQueryAdapter.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignSummary;
 import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
+import org.giglab.live.commerce.core.campaign.application.dto.ProductLinkedCampaignDto;
 import org.giglab.live.commerce.core.campaign.application.port.persistence.CampaignQueryPort;
 import org.giglab.live.commerce.core.campaign.infrastructure.persistence.CampaignQueryRepository;
 import org.springframework.stereotype.Component;
@@ -24,5 +25,10 @@ public class JpaCampaignQueryAdapter implements CampaignQueryPort {
   @Override
   public Optional<GetCampaignResult> findById(Long id) {
     return queryRepository.findById(id);
+  }
+
+  @Override
+  public List<ProductLinkedCampaignDto> findByProductId(Long productId) {
+    return queryRepository.findByProductId(productId);
   }
 }

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/persistence/CampaignQueryRepository.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/persistence/CampaignQueryRepository.java
@@ -14,6 +14,7 @@ import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignProductDto;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignSummary;
 import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
+import org.giglab.live.commerce.core.campaign.application.dto.ProductLinkedCampaignDto;
 import org.giglab.live.commerce.core.global.jpa.entity.types.YnType;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
@@ -102,6 +103,25 @@ public class CampaignQueryRepository {
             row.get(campaign.startedAt),
             row.get(campaign.endedAt),
             products));
+  }
+
+  public List<ProductLinkedCampaignDto> findByProductId(Long productId) {
+    return queryFactory
+        .select(
+            Projections.constructor(
+                ProductLinkedCampaignDto.class,
+                campaign.id,
+                campaign.title,
+                campaign.status,
+                campaign.scheduledAt,
+                campaign.startedAt,
+                campaign.endedAt))
+        .from(campaignProduct)
+        .join(campaign)
+        .on(campaign.id.eq(campaignProduct.campaign.id))
+        .where(campaignProduct.productId.eq(productId), defaultCondition())
+        .orderBy(campaign.scheduledAt.desc())
+        .fetch();
   }
 
   private BooleanExpression defaultCondition() {

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/persistence/CampaignQueryRepository.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/persistence/CampaignQueryRepository.java
@@ -14,8 +14,8 @@ import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignProductDto;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignSummary;
 import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
-import org.giglab.live.commerce.core.campaign.application.dto.ProductLinkedCampaignDto;
 import org.giglab.live.commerce.core.global.jpa.entity.types.YnType;
+import org.giglab.live.commerce.core.shared.ProductLinkedCampaignDto;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/ProductService.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/ProductService.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.giglab.live.commerce.core.product.application.dto.CreateProductCommand;
 import org.giglab.live.commerce.core.product.application.dto.CreateProductResult;
+import org.giglab.live.commerce.core.product.application.dto.GetProductLinkedCampaignsResult;
 import org.giglab.live.commerce.core.product.application.dto.GetProductListResult;
 import org.giglab.live.commerce.core.product.application.dto.GetProductResult;
 import org.giglab.live.commerce.core.product.application.dto.ProductListQuery;
@@ -16,6 +17,7 @@ import org.giglab.live.commerce.core.product.application.dto.pdf.GetDocumentList
 import org.giglab.live.commerce.core.product.application.dto.pdf.ParsedPdfData;
 import org.giglab.live.commerce.core.product.application.dto.pdf.ParsedProductResult;
 import org.giglab.live.commerce.core.product.application.usecase.CreateProductUseCase;
+import org.giglab.live.commerce.core.product.application.usecase.GetProductLinkedCampaignsUseCase;
 import org.giglab.live.commerce.core.product.application.usecase.GetProductListUseCase;
 import org.giglab.live.commerce.core.product.application.usecase.GetProductUseCase;
 import org.giglab.live.commerce.core.product.application.usecase.ai.AskProductQuestionUseCase;
@@ -34,6 +36,7 @@ public class ProductService {
 
   private final GetProductUseCase getProductUseCase;
   private final GetProductListUseCase getProductListUseCase;
+  private final GetProductLinkedCampaignsUseCase getProductLinkedCampaignsUseCase;
   private final CreateProductUseCase createProductUseCase;
   private final ParseProductPdfUseCase parseProductPdfUseCase;
   private final CreateProductDocumentUseCase createProductDocumentUseCase;
@@ -50,6 +53,10 @@ public class ProductService {
 
   public GetProductResult getDetail(Long productId) {
     return getProductUseCase.execute(productId);
+  }
+
+  public GetProductLinkedCampaignsResult getLinkedCampaigns(Long productId) {
+    return getProductLinkedCampaignsUseCase.execute(productId);
   }
 
   public CreateProductResult create(@Valid CreateProductCommand command) {

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/dto/GetProductLinkedCampaignsResult.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/dto/GetProductLinkedCampaignsResult.java
@@ -1,6 +1,6 @@
 package org.giglab.live.commerce.core.product.application.dto;
 
 import java.util.List;
-import org.giglab.live.commerce.core.campaign.application.dto.ProductLinkedCampaignDto;
+import org.giglab.live.commerce.core.shared.ProductLinkedCampaignDto;
 
 public record GetProductLinkedCampaignsResult(List<ProductLinkedCampaignDto> campaigns) {}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/dto/GetProductLinkedCampaignsResult.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/dto/GetProductLinkedCampaignsResult.java
@@ -1,0 +1,6 @@
+package org.giglab.live.commerce.core.product.application.dto;
+
+import java.util.List;
+import org.giglab.live.commerce.core.campaign.application.dto.ProductLinkedCampaignDto;
+
+public record GetProductLinkedCampaignsResult(List<ProductLinkedCampaignDto> campaigns) {}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/port/bridge/ProductCampaignAppPort.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/port/bridge/ProductCampaignAppPort.java
@@ -1,0 +1,8 @@
+package org.giglab.live.commerce.core.product.application.port.bridge;
+
+import java.util.List;
+import org.giglab.live.commerce.core.shared.ProductLinkedCampaignDto;
+
+public interface ProductCampaignAppPort {
+  List<ProductLinkedCampaignDto> getLinkedCampaignList(Long productId);
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/usecase/GetProductLinkedCampaignsUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/usecase/GetProductLinkedCampaignsUseCase.java
@@ -1,8 +1,8 @@
 package org.giglab.live.commerce.core.product.application.usecase;
 
 import lombok.RequiredArgsConstructor;
-import org.giglab.live.commerce.core.campaign.application.port.persistence.CampaignQueryPort;
 import org.giglab.live.commerce.core.product.application.dto.GetProductLinkedCampaignsResult;
+import org.giglab.live.commerce.core.product.application.port.bridge.ProductCampaignAppPort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,9 +11,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GetProductLinkedCampaignsUseCase {
 
-  private final CampaignQueryPort campaignQueryPort;
+  private final ProductCampaignAppPort productCampaignAppPort;
 
   public GetProductLinkedCampaignsResult execute(Long productId) {
-    return new GetProductLinkedCampaignsResult(campaignQueryPort.findByProductId(productId));
+    return new GetProductLinkedCampaignsResult(
+        productCampaignAppPort.getLinkedCampaignList(productId));
   }
 }

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/usecase/GetProductLinkedCampaignsUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/usecase/GetProductLinkedCampaignsUseCase.java
@@ -1,0 +1,19 @@
+package org.giglab.live.commerce.core.product.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.core.campaign.application.port.persistence.CampaignQueryPort;
+import org.giglab.live.commerce.core.product.application.dto.GetProductLinkedCampaignsResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetProductLinkedCampaignsUseCase {
+
+  private final CampaignQueryPort campaignQueryPort;
+
+  public GetProductLinkedCampaignsResult execute(Long productId) {
+    return new GetProductLinkedCampaignsResult(campaignQueryPort.findByProductId(productId));
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/usecase/GetProductLinkedCampaignsUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/usecase/GetProductLinkedCampaignsUseCase.java
@@ -3,6 +3,9 @@ package org.giglab.live.commerce.core.product.application.usecase;
 import lombok.RequiredArgsConstructor;
 import org.giglab.live.commerce.core.product.application.dto.GetProductLinkedCampaignsResult;
 import org.giglab.live.commerce.core.product.application.port.bridge.ProductCampaignAppPort;
+import org.giglab.live.commerce.core.product.application.port.persistence.ProductQueryPort;
+import org.giglab.live.commerce.core.product.domain.exception.ProductDomainException;
+import org.giglab.live.commerce.core.product.domain.exception.ProductErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,9 +14,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GetProductLinkedCampaignsUseCase {
 
+  private final ProductQueryPort productQueryPort;
   private final ProductCampaignAppPort productCampaignAppPort;
 
   public GetProductLinkedCampaignsResult execute(Long productId) {
+    if (productQueryPort.findById(productId).isEmpty()) {
+      throw new ProductDomainException(
+          ProductErrorCode.PRODUCT_NOT_FOUND, String.format("존재하지 않는 상품 %d 입니다.", productId));
+    }
     return new GetProductLinkedCampaignsResult(
         productCampaignAppPort.getLinkedCampaignList(productId));
   }

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/shared/ProductLinkedCampaignDto.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/shared/ProductLinkedCampaignDto.java
@@ -1,4 +1,4 @@
-package org.giglab.live.commerce.core.campaign.application.dto;
+package org.giglab.live.commerce.core.shared;
 
 import java.time.LocalDateTime;
 import org.giglab.live.commerce.core.campaign.domain.entity.types.BroadcastStatusType;

--- a/web-client/pages/products/[id].tsx
+++ b/web-client/pages/products/[id].tsx
@@ -34,28 +34,17 @@ interface QnAItem {
   isLoading?: boolean;
 }
 
-interface RelatedBroadcast {
-  id: string;
+interface LinkedCampaign {
+  campaignId: number;
   title: string;
-  status: 'scheduled' | 'live' | 'ended';
-  viewerCount?: number;
+  status: 'SCHEDULED' | 'ON_AIR' | 'ENDED';
+  scheduledAt: string | null;
+  startedAt: string | null;
+  endedAt: string | null;
 }
 
-const MOCK_BROADCASTS: Record<string, RelatedBroadcast[]> = {
-  P001: [
-    { id: 'B001', title: '봄맞이 뷰티 라이브', status: 'live', viewerCount: 1243 },
-  ],
-  P002: [
-    { id: 'B002', title: '스킨케어 집중 케어', status: 'scheduled' },
-  ],
-  P003: [
-    { id: 'B003', title: '파운데이션 비교 테스트', status: 'ended', viewerCount: 3892 },
-  ],
-};
-
-
-const broadcastStatusLabel = { scheduled: '예정', live: '라이브 중', ended: '종료' };
-const broadcastStatusClass = { scheduled: 'bs-scheduled', live: 'bs-live', ended: 'bs-ended' };
+const broadcastStatusLabel: Record<string, string> = { SCHEDULED: '예정', ON_AIR: '라이브 중', ENDED: '종료' };
+const broadcastStatusClass: Record<string, string> = { SCHEDULED: 'bs-scheduled', ON_AIR: 'bs-live', ENDED: 'bs-ended' };
 
 export default function ProductDetail() {
   const router = useRouter();
@@ -64,8 +53,8 @@ export default function ProductDetail() {
   const [product, setProduct] = useState<Product | null>(null);
   const [loading, setLoading] = useState(true);
   const [documents, setDocuments] = useState<ApiDocument[]>([]);
+  const [campaigns, setCampaigns] = useState<LinkedCampaign[]>([]);
   const [embeddingIds, setEmbeddingIds] = useState<Set<number>>(new Set());
-  const relatedBroadcasts = MOCK_BROADCASTS[id as string] ?? [];
 
   const [productEmbedding, setProductEmbedding] = useState(false);
   const [bulkEmbedding, setBulkEmbedding] = useState(false);
@@ -98,6 +87,16 @@ export default function ProductDetail() {
       .then((res) => res.ok ? res.json() : null)
       .then((json) => {
         if (json?.data?.items) setDocuments(json.data.items);
+      })
+      .catch(() => {});
+  }, [id]);
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`${API_BASE}/products/${id}/campaigns`)
+      .then((res) => res.ok ? res.json() : null)
+      .then((json) => {
+        if (json?.data?.campaigns) setCampaigns(json.data.campaigns);
       })
       .catch(() => {});
   }, [id]);
@@ -295,13 +294,15 @@ export default function ProductDetail() {
 
         /* 연결된 방송 */
         .broadcast-list { display: flex; flex-direction: column; gap: 8px; }
-        .b-item { display: flex; align-items: center; gap: 10px; padding: 10px 14px; background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.06); border-radius: 10px; transition: border-color 0.2s; }
-        .b-item:hover { border-color: rgba(99,102,241,0.3); }
-        .b-title { flex: 1; font-size: 13px; font-weight: 600; color: #e2e8f0; }
-        .bs-live { font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 999px; background: rgba(239,68,68,0.15); color: #fca5a5; border: 1px solid rgba(239,68,68,0.3); }
-        .bs-scheduled { font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 999px; background: rgba(251,191,36,0.12); color: #fcd34d; border: 1px solid rgba(251,191,36,0.25); }
-        .bs-ended { font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 999px; background: rgba(100,116,139,0.12); color: #94a3b8; border: 1px solid rgba(100,116,139,0.2); }
-        .b-arrow { font-size: 12px; color: #334155; }
+        .b-item { display: flex; align-items: center; gap: 12px; padding: 10px 14px; background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.06); border-radius: 8px; transition: border-color 0.2s; cursor: pointer; }
+        .b-item:hover { border-color: rgba(99,102,241,0.4); background: rgba(99,102,241,0.05); }
+        .b-info { flex: 1; min-width: 0; }
+        .b-name { font-size: 13px; font-weight: 600; color: #e2e8f0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .b-meta { font-size: 11px; color: #475569; margin-top: 2px; }
+        .b-status { flex-shrink: 0; }
+        .bs-live { font-size: 10px; font-weight: 700; padding: 2px 8px; border-radius: 999px; background: rgba(239,68,68,0.15); color: #fca5a5; border: 1px solid rgba(239,68,68,0.3); }
+        .bs-scheduled { font-size: 10px; font-weight: 700; padding: 2px 8px; border-radius: 999px; background: rgba(251,191,36,0.12); color: #fcd34d; border: 1px solid rgba(251,191,36,0.25); }
+        .bs-ended { font-size: 10px; font-weight: 700; padding: 2px 8px; border-radius: 999px; background: rgba(100,116,139,0.12); color: #94a3b8; border: 1px solid rgba(100,116,139,0.2); }
         .no-broadcast { font-size: 13px; color: #475569; text-align: center; padding: 12px 0; }
 
         @media (max-width: 800px) {
@@ -467,18 +468,30 @@ export default function ProductDetail() {
                   <div className="section-sub">이 상품이 사용된 방송 목록</div>
                 </div>
               </div>
-              {relatedBroadcasts.length === 0 ? (
+              {campaigns.length === 0 ? (
                 <div className="no-broadcast">연결된 방송이 없습니다.</div>
               ) : (
                 <div className="broadcast-list">
-                  {relatedBroadcasts.map((b) => (
-                    <Link key={b.id} href={`/broadcasts/${b.id}`} className="b-item">
-                      <span className="b-title">{b.title}</span>
-                      <span className={broadcastStatusClass[b.status]}>
-                        {b.status === 'live' && '● '}{broadcastStatusLabel[b.status]}
-                      </span>
-                      <span className="b-arrow">›</span>
-                    </Link>
+                  {campaigns.map((c) => (
+                    <div
+                      key={c.campaignId}
+                      className="b-item"
+                      onClick={() => router.push(`/broadcasts/${c.campaignId}`)}
+                    >
+                      <div className="b-info">
+                        <div className="b-name">{c.title}</div>
+                        <div className="b-meta">
+                          {c.status === 'SCHEDULED' && c.scheduledAt && `예정일: ${new Date(c.scheduledAt).toLocaleDateString('ko-KR')}`}
+                          {c.status === 'ON_AIR' && c.startedAt && `시작: ${new Date(c.startedAt).toLocaleDateString('ko-KR')}`}
+                          {c.status === 'ENDED' && c.endedAt && `종료: ${new Date(c.endedAt).toLocaleDateString('ko-KR')}`}
+                        </div>
+                      </div>
+                      <div className="b-status">
+                        <span className={broadcastStatusClass[c.status]}>
+                          {c.status === 'ON_AIR' && '● '}{broadcastStatusLabel[c.status]}
+                        </span>
+                      </div>
+                    </div>
                   ))}
                 </div>
               )}


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary

상품 상세 페이지에서 해당 상품이 편성된 방송(Campaign) 목록을 조회하는 기능을 구현합니다.
`GET /products/{id}/campaigns` 엔드포인트를 신규 추가하고, 프론트 상품 상세 페이지에서 실제 API를 호출해 연결된 방송 목록을 카드 UI로 표시합니다.


### Issue
- closes #53


### Why
- 상품 상세에서 어떤 방송에 해당 상품이 편성되어 있는지 확인할 수 없었음
- 판매자/운영자가 상품-방송 연결 관계를 한눈에 파악할 수 있도록 UX 개선 필요


### What
- `GET /products/{id}/campaigns` 엔드포인트 추가 (방송 상태·일정 포함)
- `CampaignQueryRepository`에 `productId` 기준 방송 목록 QueryDSL 조회 추가
- `CampaignQueryPort` / `JpaCampaignQueryAdapter` 메서드 추가
- `GetProductLinkedCampaignsUseCase` 신규 작성 및 `ProductService` 위임 메서드 추가
- API 응답 DTO(`LinkedCampaignItem`, `GetProductLinkedCampaignsResponse`) 및 `ProductMapper` 매핑 추가
- 프론트 상품 상세 페이지의 연결된 방송 목록을 Mock 데이터에서 실제 API 호출로 교체, 카드 UI 개선


### How
- 기존 `GET /products/{id}` 응답 계약 유지를 위해 별도 엔드포인트로 분리
- `CampaignProduct` 테이블에서 `productId` 기준으로 `campaign` JOIN 조회, `deleteYn = 'N'` 필터 및 `scheduledAt DESC` 정렬 적용
- `campaign` 모듈의 `CampaignQueryPort`를 `product` UseCase에서 직접 참조하는 방식으로 Facade 오케스트레이션 없이 단순하게 구현
- 프론트는 `Link` 대신 `div + router.push` 방식으로 변경해 flex 레이아웃 안정성 확보


### Test
- Swagger UI에서 `GET /products/{id}/campaigns` 호출 후 방송 목록 JSON 확인
- 방송이 없는 상품 ID 호출 시 `{ "campaigns": [] }` 응답 확인
- 프론트 상품 상세 페이지에서 연결된 방송 카드 UI 및 클릭 시 방송 상세 페이지 이동 확인