### PR TITLE
[#55] feat: 방송 상세 페이지 live-chat-server 채팅 웹소켓 연동

### DIFF
--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/BroadcastStatusResponse.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/BroadcastStatusResponse.java
@@ -3,4 +3,4 @@ package org.giglab.live.commerce.api.dto.campaign;
 import java.time.LocalDateTime;
 
 public record BroadcastStatusResponse(
-    String status, LocalDateTime startedAt, LocalDateTime endedAt) {}
+    String status, LocalDateTime startedAt, LocalDateTime endedAt, String chatRoomId) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/BroadcastStatusResponse.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/BroadcastStatusResponse.java
@@ -3,4 +3,8 @@ package org.giglab.live.commerce.api.dto.campaign;
 import java.time.LocalDateTime;
 
 public record BroadcastStatusResponse(
-    String status, LocalDateTime startedAt, LocalDateTime endedAt, String chatRoomId) {}
+    String title,
+    String status,
+    LocalDateTime startedAt,
+    LocalDateTime endedAt,
+    String chatRoomId) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/GetCampaignListRequest.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/GetCampaignListRequest.java
@@ -2,5 +2,7 @@ package org.giglab.live.commerce.api.dto.campaign;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import org.giglab.live.commerce.core.campaign.domain.entity.types.BroadcastStatusType;
 
-public record GetCampaignListRequest(Long cursor, @Min(1) @Max(100) Integer size, String keyword) {}
+public record GetCampaignListRequest(
+    Long cursor, @Min(1) @Max(100) Integer size, String keyword, BroadcastStatusType status) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/GetCampaignResponse.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/campaign/GetCampaignResponse.java
@@ -11,4 +11,5 @@ public record GetCampaignResponse(
     LocalDateTime scheduledAt,
     LocalDateTime startedAt,
     LocalDateTime endedAt,
+    String chatRoomId,
     List<CampaignProductItem> campaignProducts) {}

--- a/live-commerce-api/src/main/resources/application-local.yml
+++ b/live-commerce-api/src/main/resources/application-local.yml
@@ -1,6 +1,10 @@
 cors:
   allowed-origins: http://localhost:3000
 
+chat:
+  server:
+    url: ${CHAT_SERVER_URL:http://localhost:8080}
+
 app:
   upload:
     base-path: uploads

--- a/live-commerce-api/src/main/resources/application-local.yml
+++ b/live-commerce-api/src/main/resources/application-local.yml
@@ -5,6 +5,11 @@ chat:
   server:
     url: ${CHAT_SERVER_URL:http://localhost:8080}
 
+http:
+  client:
+    connect-timeout: ${HTTP_CLIENT_CONNECT_TIMEOUT:3000}
+    read-timeout: ${HTTP_CLIENT_READ_TIMEOUT:5000}
+
 app:
   upload:
     base-path: uploads

--- a/live-commerce-core/build.gradle
+++ b/live-commerce-core/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     // spring boot
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
     // spring ai
     implementation 'org.springframework.ai:spring-ai-starter-model-openai'

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
@@ -1,12 +1,15 @@
 package org.giglab.live.commerce.core.campaign.application;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.giglab.live.commerce.core.campaign.application.dto.BroadcastStatusResult;
 import org.giglab.live.commerce.core.campaign.application.dto.CampaignListQuery;
 import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignCommand;
 import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignResult;
 import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignListResult;
 import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
+import org.giglab.live.commerce.core.campaign.application.port.external.ChatRoomCreatePort;
+import org.giglab.live.commerce.core.campaign.application.usecase.AssignChatRoomUseCase;
 import org.giglab.live.commerce.core.campaign.application.usecase.CreateCampaignUseCase;
 import org.giglab.live.commerce.core.campaign.application.usecase.EndCampaignUseCase;
 import org.giglab.live.commerce.core.campaign.application.usecase.GetCampaignListUseCase;
@@ -14,6 +17,7 @@ import org.giglab.live.commerce.core.campaign.application.usecase.GetCampaignUse
 import org.giglab.live.commerce.core.campaign.application.usecase.StartCampaignUseCase;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CampaignService {
@@ -23,6 +27,8 @@ public class CampaignService {
   private final CreateCampaignUseCase createCampaignUseCase;
   private final StartCampaignUseCase startCampaignUseCase;
   private final EndCampaignUseCase endCampaignUseCase;
+  private final AssignChatRoomUseCase assignChatRoomUseCase;
+  private final ChatRoomCreatePort chatRoomCreatePort;
 
   public GetCampaignListResult getList(CampaignListQuery query) {
     return getCampaignListUseCase.execute(query);
@@ -33,7 +39,14 @@ public class CampaignService {
   }
 
   public BroadcastStatusResult start(Long campaignId) {
-    return startCampaignUseCase.execute(campaignId);
+    BroadcastStatusResult result = startCampaignUseCase.execute(campaignId);
+    if (result.chatRoomId() != null) {
+      return result;
+    }
+    String roomId = chatRoomCreatePort.createRoom(result.title());
+    assignChatRoomUseCase.execute(campaignId, roomId);
+    return new BroadcastStatusResult(
+        result.title(), result.status(), result.startedAt(), null, roomId);
   }
 
   public BroadcastStatusResult end(Long campaignId) {

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
@@ -39,14 +39,23 @@ public class CampaignService {
   }
 
   public BroadcastStatusResult start(Long campaignId) {
+    // TX 1: 방송 시작 커밋 — DB 커넥션 즉시 반환
     BroadcastStatusResult result = startCampaignUseCase.execute(campaignId);
-    if (result.chatRoomId() != null) {
-      return result;
+
+    // HTTP: 채팅방 생성 — 트랜잭션 외부
+    if (result.chatRoomId() == null) {
+      try {
+        String roomId = chatRoomCreatePort.createRoom(result.title());
+
+        // TX 2: chatRoomId 저장 커밋
+        assignChatRoomUseCase.execute(campaignId, roomId);
+        return new BroadcastStatusResult(
+            result.title(), result.status(), result.startedAt(), null, roomId);
+      } catch (Exception e) {
+        log.warn("채팅방 생성 실패 - campaignId={}", campaignId, e);
+      }
     }
-    String roomId = chatRoomCreatePort.createRoom(result.title());
-    assignChatRoomUseCase.execute(campaignId, roomId);
-    return new BroadcastStatusResult(
-        result.title(), result.status(), result.startedAt(), null, roomId);
+    return result;
   }
 
   public BroadcastStatusResult end(Long campaignId) {

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/BroadcastStatusResult.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/BroadcastStatusResult.java
@@ -4,4 +4,7 @@ import java.time.LocalDateTime;
 import org.giglab.live.commerce.core.campaign.domain.entity.types.BroadcastStatusType;
 
 public record BroadcastStatusResult(
-    BroadcastStatusType status, LocalDateTime startedAt, LocalDateTime endedAt) {}
+    BroadcastStatusType status,
+    LocalDateTime startedAt,
+    LocalDateTime endedAt,
+    String chatRoomId) {}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/BroadcastStatusResult.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/BroadcastStatusResult.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import org.giglab.live.commerce.core.campaign.domain.entity.types.BroadcastStatusType;
 
 public record BroadcastStatusResult(
+    String title,
     BroadcastStatusType status,
     LocalDateTime startedAt,
     LocalDateTime endedAt,

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/GetCampaignResult.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/dto/GetCampaignResult.java
@@ -12,4 +12,5 @@ public record GetCampaignResult(
     LocalDateTime scheduledAt,
     LocalDateTime startedAt,
     LocalDateTime endedAt,
+    String chatRoomId,
     List<CampaignProductDto> campaignProducts) {}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/port/external/ChatRoomCreatePort.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/port/external/ChatRoomCreatePort.java
@@ -1,0 +1,6 @@
+package org.giglab.live.commerce.core.campaign.application.port.external;
+
+public interface ChatRoomCreatePort {
+
+  String createRoom(String title);
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/AssignChatRoomUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/AssignChatRoomUseCase.java
@@ -1,0 +1,27 @@
+package org.giglab.live.commerce.core.campaign.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.core.campaign.application.port.persistence.CampaignStorePort;
+import org.giglab.live.commerce.core.campaign.domain.exception.CampaignDomainException;
+import org.giglab.live.commerce.core.campaign.domain.exception.CampaignErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AssignChatRoomUseCase {
+
+  private final CampaignStorePort campaignStorePort;
+
+  public void execute(Long campaignId, String chatRoomId) {
+    campaignStorePort
+        .findEntityById(campaignId)
+        .orElseThrow(
+            () ->
+                new CampaignDomainException(
+                    CampaignErrorCode.NOT_FOUND,
+                    String.format("캠페인 ID %d 를 찾을 수 없습니다.", campaignId)))
+        .assignChatRoom(chatRoomId);
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/EndCampaignUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/EndCampaignUseCase.java
@@ -25,6 +25,7 @@ public class EndCampaignUseCase {
     }
     Campaign campaign = findCampaign.get();
     campaign.end();
-    return new BroadcastStatusResult(campaign.getStatus(), null, campaign.getEndedAt());
+    return new BroadcastStatusResult(
+        campaign.getStatus(), null, campaign.getEndedAt(), campaign.getChatRoomId());
   }
 }

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/EndCampaignUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/EndCampaignUseCase.java
@@ -26,6 +26,10 @@ public class EndCampaignUseCase {
     Campaign campaign = findCampaign.get();
     campaign.end();
     return new BroadcastStatusResult(
-        campaign.getStatus(), null, campaign.getEndedAt(), campaign.getChatRoomId());
+        campaign.getTitle(),
+        campaign.getStatus(),
+        null,
+        campaign.getEndedAt(),
+        campaign.getChatRoomId());
   }
 }

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/StartCampaignUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/StartCampaignUseCase.java
@@ -2,7 +2,9 @@ package org.giglab.live.commerce.core.campaign.application.usecase;
 
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.giglab.live.commerce.core.campaign.application.dto.BroadcastStatusResult;
+import org.giglab.live.commerce.core.campaign.application.port.external.ChatRoomCreatePort;
 import org.giglab.live.commerce.core.campaign.application.port.persistence.CampaignStorePort;
 import org.giglab.live.commerce.core.campaign.domain.entity.Campaign;
 import org.giglab.live.commerce.core.campaign.domain.exception.CampaignDomainException;
@@ -10,12 +12,14 @@ import org.giglab.live.commerce.core.campaign.domain.exception.CampaignErrorCode
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class StartCampaignUseCase {
 
   private final CampaignStorePort campaignStorePort;
+  private final ChatRoomCreatePort chatRoomCreatePort;
 
   public BroadcastStatusResult execute(Long campaignId) {
     Optional<Campaign> findCampaign = campaignStorePort.findEntityById(campaignId);
@@ -25,6 +29,17 @@ public class StartCampaignUseCase {
     }
     Campaign campaign = findCampaign.get();
     campaign.start();
-    return new BroadcastStatusResult(campaign.getStatus(), campaign.getStartedAt(), null);
+
+    if (campaign.getChatRoomId() == null) {
+      try {
+        String roomId = chatRoomCreatePort.createRoom(campaign.getTitle());
+        campaign.assignChatRoom(roomId);
+      } catch (Exception e) {
+        log.warn("채팅방 생성 실패 - campaignId={}, error={}", campaignId, e.getMessage());
+      }
+    }
+
+    return new BroadcastStatusResult(
+        campaign.getStatus(), campaign.getStartedAt(), null, campaign.getChatRoomId());
   }
 }

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/StartCampaignUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/StartCampaignUseCase.java
@@ -1,10 +1,7 @@
 package org.giglab.live.commerce.core.campaign.application.usecase;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.giglab.live.commerce.core.campaign.application.dto.BroadcastStatusResult;
-import org.giglab.live.commerce.core.campaign.application.port.external.ChatRoomCreatePort;
 import org.giglab.live.commerce.core.campaign.application.port.persistence.CampaignStorePort;
 import org.giglab.live.commerce.core.campaign.domain.entity.Campaign;
 import org.giglab.live.commerce.core.campaign.domain.exception.CampaignDomainException;
@@ -12,34 +9,28 @@ import org.giglab.live.commerce.core.campaign.domain.exception.CampaignErrorCode
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class StartCampaignUseCase {
 
   private final CampaignStorePort campaignStorePort;
-  private final ChatRoomCreatePort chatRoomCreatePort;
 
   public BroadcastStatusResult execute(Long campaignId) {
-    Optional<Campaign> findCampaign = campaignStorePort.findEntityById(campaignId);
-    if (findCampaign.isEmpty()) {
-      throw new CampaignDomainException(
-          CampaignErrorCode.NOT_FOUND, String.format("캠페인 ID %d 를 찾을 수 없습니다.", campaignId));
-    }
-    Campaign campaign = findCampaign.get();
+    Campaign campaign =
+        campaignStorePort
+            .findEntityById(campaignId)
+            .orElseThrow(
+                () ->
+                    new CampaignDomainException(
+                        CampaignErrorCode.NOT_FOUND,
+                        String.format("캠페인 ID %d 를 찾을 수 없습니다.", campaignId)));
     campaign.start();
-
-    if (campaign.getChatRoomId() == null) {
-      try {
-        String roomId = chatRoomCreatePort.createRoom(campaign.getTitle());
-        campaign.assignChatRoom(roomId);
-      } catch (Exception e) {
-        log.warn("채팅방 생성 실패 - campaignId={}, error={}", campaignId, e.getMessage());
-      }
-    }
-
     return new BroadcastStatusResult(
-        campaign.getStatus(), campaign.getStartedAt(), null, campaign.getChatRoomId());
+        campaign.getTitle(),
+        campaign.getStatus(),
+        campaign.getStartedAt(),
+        null,
+        campaign.getChatRoomId());
   }
 }

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/Campaign.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/Campaign.java
@@ -69,6 +69,9 @@ public class Campaign extends AuditedEntity {
 
   private LocalDateTime endedAt;
 
+  @Column(name = "chat_room_id", length = 30)
+  private String chatRoomId;
+
   public static Campaign create(String title, String description, LocalDateTime scheduledAt) {
     return Campaign.builder()
         .title(title)
@@ -87,6 +90,10 @@ public class Campaign extends AuditedEntity {
     }
     this.status = BroadcastStatusType.ON_AIR;
     this.startedAt = LocalDateTime.now();
+  }
+
+  public void assignChatRoom(String chatRoomId) {
+    this.chatRoomId = chatRoomId;
   }
 
   public void end() {

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/Campaign.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/Campaign.java
@@ -93,6 +93,10 @@ public class Campaign extends AuditedEntity {
   }
 
   public void assignChatRoom(String chatRoomId) {
+    if (this.chatRoomId != null) {
+      throw new CampaignDomainException(
+          CampaignErrorCode.INVALID_STATUS_CHANGE, "이미 채팅방이 할당된 캠페인입니다.");
+    }
     this.chatRoomId = chatRoomId;
   }
 

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/client/RestChatServerClient.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/client/RestChatServerClient.java
@@ -1,0 +1,48 @@
+package org.giglab.live.commerce.core.campaign.infrastructure.client;
+
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.giglab.live.commerce.core.campaign.application.port.external.ChatRoomCreatePort;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RestChatServerClient implements ChatRoomCreatePort {
+
+  private final RestTemplate restTemplate;
+
+  @Value("${chat.server.url}")
+  private String chatServerUrl;
+
+  @Override
+  public String createRoom(String title) {
+    String url = chatServerUrl + "/api/v1/rooms";
+    HttpEntity<CreateRoomRequest> request = new HttpEntity<>(new CreateRoomRequest(title));
+
+    ResponseEntity<ChatApiResponse<CreateRoomResponse>> response =
+        restTemplate.exchange(url, HttpMethod.POST, request, new ParameterizedTypeReference<>() {});
+
+    ChatApiResponse<CreateRoomResponse> body = response.getBody();
+    if (body == null || body.data() == null || body.data().roomId() == null) {
+      throw new IllegalStateException("채팅방 생성 응답이 없습니다.");
+    }
+
+    log.info("채팅방 생성 완료 - roomId={}, title={}", body.data().roomId(), title);
+    return body.data().roomId();
+  }
+
+  private record CreateRoomRequest(String title) {}
+
+  private record CreateRoomResponse(
+      String roomId, String title, Instant createdAt, Instant updatedAt) {}
+
+  private record ChatApiResponse<T>(T data) {}
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/persistence/CampaignQueryRepository.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/persistence/CampaignQueryRepository.java
@@ -71,7 +71,8 @@ public class CampaignQueryRepository {
                 campaign.status,
                 campaign.scheduledAt,
                 campaign.startedAt,
-                campaign.endedAt)
+                campaign.endedAt,
+                campaign.chatRoomId)
             .from(campaign)
             .where(defaultCondition(), eqCampaignId(campaignId))
             .fetchOne();
@@ -102,6 +103,7 @@ public class CampaignQueryRepository {
             row.get(campaign.scheduledAt),
             row.get(campaign.startedAt),
             row.get(campaign.endedAt),
+            row.get(campaign.chatRoomId),
             products));
   }
 

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/global/config/RestTemplateConfig.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/global/config/RestTemplateConfig.java
@@ -1,5 +1,8 @@
 package org.giglab.live.commerce.core.global.config;
 
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -7,8 +10,17 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class RestTemplateConfig {
 
+  @Value("${http.client.connect-timeout:3000}")
+  private int connectTimeoutMs;
+
+  @Value("${http.client.read-timeout:5000}")
+  private int readTimeoutMs;
+
   @Bean
-  public RestTemplate restTemplate() {
-    return new RestTemplate();
+  public RestTemplate restTemplate(RestTemplateBuilder builder) {
+    return builder
+        .connectTimeout(Duration.ofMillis(connectTimeoutMs))
+        .readTimeout(Duration.ofMillis(readTimeoutMs))
+        .build();
   }
 }

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/global/config/RestTemplateConfig.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/global/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package org.giglab.live.commerce.core.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/web-client/pages/broadcasts/[id].tsx
+++ b/web-client/pages/broadcasts/[id].tsx
@@ -105,6 +105,7 @@ function ChatQnAPanel({
   nickname,
   setNickname,
   onSend,
+  wsConnected,
 }: {
   status: BroadcastStatus;
   productName: string;
@@ -114,8 +115,10 @@ function ChatQnAPanel({
   nickname: string;
   setNickname: (v: string) => void;
   onSend: () => void;
+  wsConnected: boolean;
 }) {
   const isScheduled = status === 'scheduled';
+  const isLive = status === 'live';
   const [tab, setTab] = useState<'chat' | 'faq'>('chat');
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const faqBottomRef = useRef<HTMLDivElement>(null);
@@ -204,7 +207,7 @@ function ChatQnAPanel({
             <>
               <div className="lp-nick-row">
                 <span className="lp-nick-label">닉네임</span>
-                <input className="lp-nick-input" value={nickname} onChange={(e) => setNickname(e.target.value)} maxLength={20} disabled={isScheduled} />
+                <input className="lp-nick-input" value={nickname} onChange={(e) => setNickname(e.target.value)} maxLength={20} disabled={isScheduled || (isLive && !wsConnected)} />
               </div>
               <div className="lp-input-row">
                 <input
@@ -212,10 +215,10 @@ function ChatQnAPanel({
                   value={inputValue}
                   onChange={(e) => setInputValue(e.target.value)}
                   onKeyPress={handleKey}
-                  placeholder={isScheduled ? '방송 시작 전입니다.' : '메시지를 입력하세요...'}
-                  disabled={isScheduled}
+                  placeholder={isScheduled ? '방송 시작 전입니다.' : isLive && !wsConnected ? '채팅 연결 중...' : '메시지를 입력하세요...'}
+                  disabled={isScheduled || (isLive && !wsConnected)}
                 />
-                <button className="lp-send" onClick={onSend} disabled={isScheduled || !inputValue.trim()}>전송</button>
+                <button className="lp-send" onClick={onSend} disabled={isScheduled || (isLive && !wsConnected) || !inputValue.trim()}>전송</button>
               </div>
             </>
           )}
@@ -496,6 +499,7 @@ export default function BroadcastDetail() {
   const clientRef = useRef<any>(null);
   const subRef = useRef<any>(null);
   const seenKeysRef = useRef<Set<string>>(new Set());
+  const isConnectingRef = useRef(false);
 
   const WS_BASE_URL = process.env.NEXT_PUBLIC_WS_URL ?? 'http://localhost:8080';
 
@@ -558,6 +562,7 @@ export default function BroadcastDetail() {
       const json = await res.json();
       const data: BroadcastStatusData = json.data;
       setCampaign((prev) => prev ? { ...prev, status: data.status, startedAt: data.startedAt, chatRoomId: data.chatRoomId ?? prev.chatRoomId } : prev);
+      if (data.chatRoomId) connect(data.chatRoomId);
     } catch {
       alert('방송 시작에 실패했습니다.');
     } finally {
@@ -631,6 +636,7 @@ export default function BroadcastDetail() {
   };
 
   const disconnect = () => {
+    isConnectingRef.current = false;
     publishLeave();
     try { subRef.current?.unsubscribe?.(); clientRef.current?.disconnect?.(); } finally {
       clientRef.current = null; subRef.current = null; setWsConnected(false);
@@ -639,19 +645,24 @@ export default function BroadcastDetail() {
 
   const connect = (roomId: string) => {
     if (!areScriptsReady || !roomId) return;
+    if (isConnectingRef.current || clientRef.current) return;
     const SockJS = (window as any).SockJS;
     const StompJs = (window as any).StompJs;
     if (!SockJS || !StompJs) return;
-    disconnect();
+    isConnectingRef.current = true;
     const socket = new SockJS(`${WS_BASE_URL}/ws`);
     const client = StompJs.Stomp.over(socket);
     client.debug = () => {};
     client.connect({}, () => {
+      isConnectingRef.current = false;
       clientRef.current = client;
       setWsConnected(true);
       subRef.current = client.subscribe(`/sub/room/${roomId}`, (msg: any) => appendMessage(msg?.body ?? ''));
       publishJoin(client, roomId);
-    }, () => setWsConnected(false));
+    }, () => {
+      isConnectingRef.current = false;
+      setWsConnected(false);
+    });
   };
 
   const sendMessage = () => {
@@ -676,7 +687,7 @@ export default function BroadcastDetail() {
   useEffect(() => {
     if (!campaign || !areScriptsReady) return;
     const uiStatus = toUiStatus(campaign.status);
-    if (uiStatus === 'live' && campaign.chatRoomId && !wsConnected) {
+    if (uiStatus === 'live' && campaign.chatRoomId && !wsConnected && !isConnectingRef.current) {
       connect(campaign.chatRoomId);
     }
     if (uiStatus === 'ended' && wsConnected) {
@@ -949,6 +960,7 @@ export default function BroadcastDetail() {
                 nickname={nickname}
                 setNickname={setNickname}
                 onSend={sendMessage}
+                wsConnected={wsConnected}
               />
             )}
             {uiStatus === 'ended' && <EndedAnalysisPanel />}

--- a/web-client/pages/broadcasts/[id].tsx
+++ b/web-client/pages/broadcasts/[id].tsx
@@ -10,6 +10,7 @@ interface BroadcastStatusData {
   status: string;
   startedAt: string | null;
   endedAt: string | null;
+  chatRoomId: string | null;
 }
 
 interface CampaignProduct {
@@ -26,6 +27,7 @@ interface Campaign {
   scheduledAt: string | null;
   startedAt: string | null;
   endedAt: string | null;
+  chatRoomId: string | null;
   campaignProducts: CampaignProduct[];
 }
 
@@ -103,9 +105,6 @@ function ChatQnAPanel({
   nickname,
   setNickname,
   onSend,
-  wsConnected,
-  onToggleWs,
-  areScriptsReady,
 }: {
   status: BroadcastStatus;
   productName: string;
@@ -115,9 +114,6 @@ function ChatQnAPanel({
   nickname: string;
   setNickname: (v: string) => void;
   onSend: () => void;
-  wsConnected: boolean;
-  onToggleWs: () => void;
-  areScriptsReady: boolean;
 }) {
   const isScheduled = status === 'scheduled';
   const [tab, setTab] = useState<'chat' | 'faq'>('chat');
@@ -179,15 +175,6 @@ function ChatQnAPanel({
             {!isScheduled && <span className="faq-count">{liveFaqs.length}</span>}
           </button>
         </div>
-        {!isScheduled && (
-          <button
-            className={`ws-btn ${wsConnected ? 'connected' : 'disconnected'}`}
-            onClick={onToggleWs}
-            disabled={!areScriptsReady && !wsConnected}
-          >
-            {wsConnected ? '● 연결됨' : '연결'}
-          </button>
-        )}
       </div>
 
       {tab === 'chat' ? (
@@ -211,20 +198,27 @@ function ChatQnAPanel({
             )}
             <div ref={messagesEndRef} />
           </div>
-          <div className="lp-nick-row">
-            <span className="lp-nick-label">닉네임</span>
-            <input className="lp-nick-input" value={nickname} onChange={(e) => setNickname(e.target.value)} maxLength={20} />
-          </div>
-          <div className="lp-input-row">
-            <input
-              className="lp-input"
-              value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              onKeyPress={handleKey}
-              placeholder={isScheduled ? '리허설 메시지를 입력하세요...' : '메시지를 입력하세요...'}
-            />
-            <button className="lp-send" onClick={onSend} disabled={!inputValue.trim()}>전송</button>
-          </div>
+          {status === 'ended' ? (
+            <div className="lp-ended-notice">방송이 종료되었습니다.</div>
+          ) : (
+            <>
+              <div className="lp-nick-row">
+                <span className="lp-nick-label">닉네임</span>
+                <input className="lp-nick-input" value={nickname} onChange={(e) => setNickname(e.target.value)} maxLength={20} disabled={isScheduled} />
+              </div>
+              <div className="lp-input-row">
+                <input
+                  className="lp-input"
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  onKeyPress={handleKey}
+                  placeholder={isScheduled ? '방송 시작 전입니다.' : '메시지를 입력하세요...'}
+                  disabled={isScheduled}
+                />
+                <button className="lp-send" onClick={onSend} disabled={isScheduled || !inputValue.trim()}>전송</button>
+              </div>
+            </>
+          )}
         </>
       ) : isScheduled ? (
         /* 예정: AI Q&A 탭 */
@@ -294,6 +288,7 @@ function ChatQnAPanel({
         .lp-messages::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 2px; }
         .lp-empty { color: #475569; font-size: 13px; text-align: center; margin-top: 40px; }
         .lp-rehearsal-banner { padding: 7px 16px; background: rgba(251,191,36,0.08); border-bottom: 1px solid rgba(251,191,36,0.15); font-size: 11px; font-weight: 600; color: #fcd34d; text-align: center; letter-spacing: 0.02em; }
+        .lp-ended-notice { padding: 14px 16px; font-size: 12px; color: #64748b; text-align: center; border-top: 1px solid rgba(255,255,255,0.07); }
         .msg { display: flex; flex-direction: column; gap: 2px; }
         .msg-header { display: flex; align-items: center; gap: 6px; }
         .msg-nick { font-size: 12px; font-weight: 700; color: #818cf8; }
@@ -502,8 +497,7 @@ export default function BroadcastDetail() {
   const subRef = useRef<any>(null);
   const seenKeysRef = useRef<Set<string>>(new Set());
 
-  const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
-  const WS_BASE_URL = process.env.NEXT_PUBLIC_WS_URL || API_BASE_URL;
+  const WS_BASE_URL = process.env.NEXT_PUBLIC_WS_URL ?? 'http://localhost:8080';
 
   useEffect(() => {
     if (!id) return;
@@ -563,7 +557,7 @@ export default function BroadcastDetail() {
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();
       const data: BroadcastStatusData = json.data;
-      setCampaign((prev) => prev ? { ...prev, status: data.status, startedAt: data.startedAt } : prev);
+      setCampaign((prev) => prev ? { ...prev, status: data.status, startedAt: data.startedAt, chatRoomId: data.chatRoomId ?? prev.chatRoomId } : prev);
     } catch {
       alert('방송 시작에 실패했습니다.');
     } finally {
@@ -597,6 +591,7 @@ export default function BroadcastDetail() {
     seenKeysRef.current.add(rawBody);
     try {
       const p = JSON.parse(rawBody ?? '{}') as any;
+      if (p.action !== 'CHAT.MESSAGE') return;
       const text = p.payload?.message ?? rawBody;
       const nick = p.actor?.sender || p.actor?.username || '시청자';
       const ts = p.sentAt ? new Date(p.sentAt) : new Date();
@@ -606,14 +601,44 @@ export default function BroadcastDetail() {
     }
   };
 
+  const publishJoin = (client: any, roomId: string) => {
+    const nick = nickname.trim() || '시청자';
+    try {
+      client.send('/send/room.action', {}, JSON.stringify({
+        roomId,
+        action: 'CHAT.JOIN',
+        actor: { userId: nick, username: nick, sender: nick },
+        payload: {},
+      }));
+    } catch {
+      // join 실패는 무시
+    }
+  };
+
+  const publishLeave = () => {
+    if (!wsConnected || !clientRef.current || !campaign?.chatRoomId) return;
+    const nick = nickname.trim() || '시청자';
+    try {
+      clientRef.current.send('/send/room.action', {}, JSON.stringify({
+        roomId: campaign.chatRoomId,
+        action: 'CHAT.LEAVE',
+        actor: { userId: nick, username: nick, sender: nick },
+        payload: {},
+      }));
+    } catch {
+      // leave 실패는 무시
+    }
+  };
+
   const disconnect = () => {
+    publishLeave();
     try { subRef.current?.unsubscribe?.(); clientRef.current?.disconnect?.(); } finally {
       clientRef.current = null; subRef.current = null; setWsConnected(false);
     }
   };
 
-  const connect = () => {
-    if (!areScriptsReady) return;
+  const connect = (roomId: string) => {
+    if (!areScriptsReady || !roomId) return;
     const SockJS = (window as any).SockJS;
     const StompJs = (window as any).StompJs;
     if (!SockJS || !StompJs) return;
@@ -624,33 +649,41 @@ export default function BroadcastDetail() {
     client.connect({}, () => {
       clientRef.current = client;
       setWsConnected(true);
-      subRef.current = client.subscribe(`/sub/room/${id}`, (msg: any) => appendMessage(msg?.body ?? ''));
+      subRef.current = client.subscribe(`/sub/room/${roomId}`, (msg: any) => appendMessage(msg?.body ?? ''));
+      publishJoin(client, roomId);
     }, () => setWsConnected(false));
   };
 
-  const handleToggleWs = () => wsConnected ? disconnect() : connect();
-
   const sendMessage = () => {
-    if (!inputValue.trim()) return;
+    if (!inputValue.trim() || !campaign?.chatRoomId) return;
     const nick = nickname.trim() || '시청자';
     const text = inputValue.trim();
     if (wsConnected && clientRef.current) {
       try {
         clientRef.current.send('/send/room.action', {}, JSON.stringify({
-          roomId: id, action: 'CHAT.MESSAGE',
+          roomId: campaign.chatRoomId, action: 'CHAT.MESSAGE',
           actor: { userId: nick, username: nick, sender: nick },
           payload: { message: text },
         }));
       } catch {
         setMessages((prev) => [...prev, { id: Date.now(), nickname: nick, text, timestamp: new Date() }]);
       }
-    } else {
-      setMessages((prev) => [...prev, { id: Date.now(), nickname: nick, text, timestamp: new Date() }]);
     }
     setInputValue('');
   };
 
-  useEffect(() => () => { disconnect(); }, []);
+  // 방송 상태에 따른 자동 WebSocket 연결/해제
+  useEffect(() => {
+    if (!campaign || !areScriptsReady) return;
+    const uiStatus = toUiStatus(campaign.status);
+    if (uiStatus === 'live' && campaign.chatRoomId && !wsConnected) {
+      connect(campaign.chatRoomId);
+    }
+    if (uiStatus === 'ended' && wsConnected) {
+      disconnect();
+    }
+    return () => { disconnect(); };
+  }, [campaign?.status, campaign?.chatRoomId, areScriptsReady]);
 
   if (!id) return null;
 
@@ -687,6 +720,7 @@ export default function BroadcastDetail() {
   const uiStatus = toUiStatus(campaign.status);
   const isLive = uiStatus === 'live';
   const isScheduled = uiStatus === 'scheduled';
+  const isEnded = uiStatus === 'ended';
   const productName = campaign.campaignProducts[0]?.name ?? '상품 없음';
   const startedAtLabel = campaign.startedAt
     ? new Date(campaign.startedAt).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
@@ -905,7 +939,7 @@ export default function BroadcastDetail() {
 
           {/* 우측 패널: 상태별 */}
           <div className="side-col">
-            {(isScheduled || isLive) && (
+            {(isScheduled || isLive || isEnded) && (
               <ChatQnAPanel
                 status={uiStatus}
                 productName={productName}
@@ -915,9 +949,6 @@ export default function BroadcastDetail() {
                 nickname={nickname}
                 setNickname={setNickname}
                 onSend={sendMessage}
-                wsConnected={wsConnected}
-                onToggleWs={handleToggleWs}
-                areScriptsReady={areScriptsReady}
               />
             )}
             {uiStatus === 'ended' && <EndedAnalysisPanel />}


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
방송 시작 시 live-chat-server에 채팅방을 생성하고, 생성된 `chatRoomId`를 Campaign에 저장해 프론트엔드가 올바른 STOMP 채널에 자동으로 연결되도록 전체 연동 흐름을 구현합니다.


### Issue
- closes #55


### Why
- 기존 코드는 campaignId(정수)를 roomId로 잘못 사용하고 있었고, 실제 chat-server에 채팅방 생성 요청을 보내지 않아 WebSocket 채널이 올바르게 연결되지 않았습니다.
- 방송 상태(SCHEDULED / ON_AIR / ENDED)에 따른 자동 연결/해제 및 입장·퇴장 알림이 없었습니다.


### What
- **Backend**
  - `Campaign` 엔티티에 `chat_room_id` 컬럼 추가 및 `assignChatRoom()` 도메인 메서드 추가
  - `ChatRoomCreatePort` 아웃바운드 포트 인터페이스 추가 (hexagonal architecture)
  - `RestChatServerClient` — `POST /api/v1/rooms` 호출 구현체 추가 (`live-commerce-core` 캠페인 인프라에 위치)
  - `RestTemplateConfig` 빈 등록 및 `live-commerce-core` `spring-boot-starter-web` 의존성 추가
  - `StartCampaignUseCase` — 방송 시작 시 채팅방 생성 후 `chatRoomId` 저장 (chat-server 실패 시 방송은 정상 진행)
  - `BroadcastStatusResult`, `GetCampaignResult` 및 API DTO에 `chatRoomId` 필드 추가

- **Frontend (`broadcasts/[id].tsx`)**
  - `Campaign` 인터페이스에 `chatRoomId` 필드 추가
  - `connect(roomId)` 함수 — `/sub/room/${roomId}` 구독 경로 수정
  - `isConnectingRef` 플래그로 중복 연결 방지
  - `handleStart` 직접 `connect()` 호출 — 방송 시작 즉시 WebSocket 연결
  - auto-connect `useEffect` — 새로고침 시 ON_AIR 상태에서 자동 연결
  - `publishJoin` / `publishLeave` — CHAT.JOIN / CHAT.LEAVE 액션 자동 발행
  - `appendMessage` 필터 — `CHAT.MESSAGE` 액션만 채팅창에 표시
  - 방송 상태별 채팅 UI 제어 (SCHEDULED: 비활성, ON_AIR: 활성, ENDED: 읽기전용)
  - 수동 "연결" 버튼 제거, 자동 연결로 대체


### How
- **헥사고날 아키텍처 준수**: chat-server HTTP 호출을 `ChatRoomCreatePort` (포트) + `RestChatServerClient` (어댑터) 구조로 분리. `live-commerce-api`가 아닌 `live-commerce-core` campaign 인프라에 위치.
- **장애 방어**: `StartCampaignUseCase`에서 채팅방 생성 실패 시 `log.warn`만 남기고 방송은 정상 진행 (`chatRoomId=null`). 프론트는 null이면 채팅 미연결.
- **중복 연결 방지**: `isConnectingRef`(ref)로 연결 진행 중 상태를 동기적으로 추적해 React Strict Mode 이중 실행 환경에서도 단일 연결 보장.
- **STOMP 메시지 필터**: `appendMessage`에서 `action !== 'CHAT.MESSAGE'`인 경우 early return으로 JOIN/LEAVE/SYSTEM 액션이 채팅창에 노출되지 않도록 처리.
- `chat.server.url`은 `application-local.yml`의 `${CHAT_SERVER_URL:http://localhost:8080}`으로 환경변수 주입.


### Test
- 방송 시작 버튼 클릭 → `chatRoomId` 응답 확인 후 즉시 WebSocket 연결 및 "채팅 연결 중..." → 활성 전환 확인
- 두 개 탭에서 같은 방송 페이지 열기 → 한 탭 메시지 입력 시 다른 탭 실시간 수신 확인
- 방송 종료 → 자동 disconnect 및 입력창 읽기전용 확인
- chat-server 중단 상태에서 방송 시작 → 경고 로그만 출력되고 방송 정상 시작 확인