### PR TITLE
[#57] feat: 방송 종료 시 채팅방 삭제 및 live-chat-server DELETE API 구현

### DIFF
--- a/live-chat-server/src/main/java/org/giglab/live/application/service/RoomService.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/service/RoomService.java
@@ -26,6 +26,10 @@ public class RoomService {
         saved.getRoomId(), saved.getTitle(), saved.getCreatedAt(), saved.getUpdatedAt());
   }
 
+  public void deleteRoom(String roomId) {
+    roomRepository.deleteById(roomId);
+  }
+
   public List<GetRoomResponse> getRooms(int size) {
     int validSize = Math.min(MAX_SIZE, size);
     List<String> roomIds = roomRepository.findLatestRoomIds(validSize);

--- a/live-chat-server/src/main/java/org/giglab/live/domain/repository/RoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/domain/repository/RoomRepository.java
@@ -14,4 +14,6 @@ public interface RoomRepository {
   Stream<Room> getRoomsByIds(List<String> roomIds);
 
   Optional<Room> findById(String roomId);
+
+  void deleteById(String roomId);
 }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
@@ -174,6 +174,38 @@ public class RedisRoomRepository implements RoomRepository {
     }
   }
 
+  @Override
+  public void deleteById(String roomId) {
+    String roomKey = String.format("%s:%s", ROOM_KEY_PREFIX, roomId);
+
+    try {
+      List<Object> results =
+          redisTemplate.execute(
+              new SessionCallback<List<Object>>() {
+                @Override
+                @SuppressWarnings("unchecked")
+                public <K, V> List<Object> execute(RedisOperations<K, V> operations)
+                    throws DataAccessException {
+                  operations.multi();
+                  operations.delete((K) roomKey);
+                  operations.opsForZSet().remove((K) ROOM_INDEX_KEY, (V) roomId);
+                  return operations.exec();
+                }
+              });
+
+      if (results == null) {
+        throw new RedisOperationException("DELETE", roomKey, "Transaction returned null", null);
+      }
+      log.info("채팅방 삭제 완료 - roomId={}", roomId);
+
+    } catch (RedisOperationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Failed to delete room: roomId={}, error={}", roomId, e.getMessage(), e);
+      throw new RedisOperationException("DELETE", roomKey, e.getMessage(), e);
+    }
+  }
+
   private Room convertToRoom(Object obj) {
     if (obj == null) {
       return null;

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RedisRoomRepository.java
@@ -196,7 +196,12 @@ public class RedisRoomRepository implements RoomRepository {
       if (results == null) {
         throw new RedisOperationException("DELETE", roomKey, "Transaction returned null", null);
       }
-      log.info("채팅방 삭제 완료 - roomId={}", roomId);
+      long deleted = results.getFirst() instanceof Long l ? l : 0L;
+      if (deleted > 0) {
+        log.info("채팅방 삭제 완료 - roomId={}, deleted={}", roomId, deleted);
+      } else {
+        log.debug("채팅방 삭제 요청 - 이미 존재하지 않는 roomId={}", roomId);
+      }
 
     } catch (RedisOperationException e) {
       throw e;

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/RoomController.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/RoomController.java
@@ -11,7 +11,9 @@ import org.giglab.live.application.service.RoomService;
 import org.giglab.live.presentation.api.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +32,12 @@ public class RoomController {
       @RequestParam(defaultValue = "10") @Positive int size) {
     List<GetRoomResponse> responses = roomService.getRooms(size);
     return new ResponseEntity<>(ApiResponse.success(responses), HttpStatus.OK);
+  }
+
+  @DeleteMapping("/{roomId}")
+  public ResponseEntity<Void> deleteRoom(@PathVariable String roomId) {
+    roomService.deleteRoom(roomId);
+    return ResponseEntity.noContent().build();
   }
 
   @PostMapping

--- a/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/RoomControllerTest.java
+++ b/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/RoomControllerTest.java
@@ -2,6 +2,9 @@ package org.giglab.live.presentation.api.v1.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -190,5 +193,37 @@ class RoomControllerTest {
         .andExpect(jsonPath("$.data[0].title").value("최신 채팅방"))
         .andExpect(jsonPath("$.data[1].roomId").value("ROOM_002"))
         .andExpect(jsonPath("$.data[2].roomId").value("ROOM_001")); // 오래된 것이 마지막
+  }
+
+  @Test
+  @DisplayName("채팅방 삭제 성공 - 204 NO_CONTENT")
+  void deleteRoomSuccessReturns204() throws Exception {
+    // given
+    String roomId = "ROOM_123456789ABC";
+    willDoNothing().given(roomService).deleteRoom(roomId);
+
+    // when & then
+    mockMvc
+        .perform(delete("/api/v1/rooms/{roomId}", roomId))
+        .andDo(print())
+        .andExpect(status().isNoContent());
+
+    verify(roomService).deleteRoom(roomId);
+  }
+
+  @Test
+  @DisplayName("채팅방 삭제 - 존재하지 않는 roomId도 204 NO_CONTENT (idempotent)")
+  void deleteRoomNotExistsReturns204() throws Exception {
+    // given
+    String roomId = "ROOM_NOTEXISTS0000";
+    willDoNothing().given(roomService).deleteRoom(roomId);
+
+    // when & then
+    mockMvc
+        .perform(delete("/api/v1/rooms/{roomId}", roomId))
+        .andDo(print())
+        .andExpect(status().isNoContent());
+
+    verify(roomService).deleteRoom(roomId);
   }
 }

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
@@ -70,14 +70,25 @@ public class CampaignService {
     if (result.chatRoomId() != null) {
       try {
         chatRoomDeletePort.deleteRoom(result.chatRoomId());
-
-        // TX 2: chatRoomId 초기화 커밋
-        clearChatRoomUseCase.execute(campaignId);
-        return new BroadcastStatusResult(
-            result.title(), result.status(), result.startedAt(), result.endedAt(), null);
       } catch (Exception e) {
-        log.warn("채팅방 삭제 실패 - campaignId={}", campaignId, e);
+        log.warn("채팅방 삭제 실패 (chat-server) - campaignId={}", campaignId, e);
+        return result;
       }
+
+      // TX 2: chatRoomId 초기화 커밋
+      try {
+        clearChatRoomUseCase.execute(campaignId);
+      } catch (Exception e) {
+        log.warn(
+            "chatRoomId 초기화 실패 (DB) - campaignId={}, chatRoomId={}",
+            campaignId,
+            result.chatRoomId(),
+            e);
+        return result;
+      }
+
+      return new BroadcastStatusResult(
+          result.title(), result.status(), result.startedAt(), result.endedAt(), null);
     }
 
     return result;

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
@@ -11,6 +11,7 @@ import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
 import org.giglab.live.commerce.core.campaign.application.port.external.ChatRoomCreatePort;
 import org.giglab.live.commerce.core.campaign.application.port.external.ChatRoomDeletePort;
 import org.giglab.live.commerce.core.campaign.application.usecase.AssignChatRoomUseCase;
+import org.giglab.live.commerce.core.campaign.application.usecase.ClearChatRoomUseCase;
 import org.giglab.live.commerce.core.campaign.application.usecase.CreateCampaignUseCase;
 import org.giglab.live.commerce.core.campaign.application.usecase.EndCampaignUseCase;
 import org.giglab.live.commerce.core.campaign.application.usecase.GetCampaignListUseCase;
@@ -29,6 +30,7 @@ public class CampaignService {
   private final StartCampaignUseCase startCampaignUseCase;
   private final EndCampaignUseCase endCampaignUseCase;
   private final AssignChatRoomUseCase assignChatRoomUseCase;
+  private final ClearChatRoomUseCase clearChatRoomUseCase;
   private final ChatRoomCreatePort chatRoomCreatePort;
   private final ChatRoomDeletePort chatRoomDeletePort;
 
@@ -68,6 +70,9 @@ public class CampaignService {
     if (result.chatRoomId() != null) {
       try {
         chatRoomDeletePort.deleteRoom(result.chatRoomId());
+
+        // TX 2: chatRoomId 초기화 커밋
+        clearChatRoomUseCase.execute(campaignId);
         return new BroadcastStatusResult(
             result.title(), result.status(), result.startedAt(), result.endedAt(), null);
       } catch (Exception e) {

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/CampaignService.java
@@ -9,6 +9,7 @@ import org.giglab.live.commerce.core.campaign.application.dto.CreateCampaignResu
 import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignListResult;
 import org.giglab.live.commerce.core.campaign.application.dto.GetCampaignResult;
 import org.giglab.live.commerce.core.campaign.application.port.external.ChatRoomCreatePort;
+import org.giglab.live.commerce.core.campaign.application.port.external.ChatRoomDeletePort;
 import org.giglab.live.commerce.core.campaign.application.usecase.AssignChatRoomUseCase;
 import org.giglab.live.commerce.core.campaign.application.usecase.CreateCampaignUseCase;
 import org.giglab.live.commerce.core.campaign.application.usecase.EndCampaignUseCase;
@@ -29,6 +30,7 @@ public class CampaignService {
   private final EndCampaignUseCase endCampaignUseCase;
   private final AssignChatRoomUseCase assignChatRoomUseCase;
   private final ChatRoomCreatePort chatRoomCreatePort;
+  private final ChatRoomDeletePort chatRoomDeletePort;
 
   public GetCampaignListResult getList(CampaignListQuery query) {
     return getCampaignListUseCase.execute(query);
@@ -59,7 +61,21 @@ public class CampaignService {
   }
 
   public BroadcastStatusResult end(Long campaignId) {
-    return endCampaignUseCase.execute(campaignId);
+    // TX 1: 방송 종료 커밋 — DB 커넥션 즉시 반환
+    BroadcastStatusResult result = endCampaignUseCase.execute(campaignId);
+
+    // HTTP: 채팅방 삭제 — 트랜잭션 외부
+    if (result.chatRoomId() != null) {
+      try {
+        chatRoomDeletePort.deleteRoom(result.chatRoomId());
+        return new BroadcastStatusResult(
+            result.title(), result.status(), result.startedAt(), result.endedAt(), null);
+      } catch (Exception e) {
+        log.warn("채팅방 삭제 실패 - campaignId={}", campaignId, e);
+      }
+    }
+
+    return result;
   }
 
   public CreateCampaignResult create(CreateCampaignCommand request) {

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/port/external/ChatRoomDeletePort.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/port/external/ChatRoomDeletePort.java
@@ -1,0 +1,6 @@
+package org.giglab.live.commerce.core.campaign.application.port.external;
+
+public interface ChatRoomDeletePort {
+
+  void deleteRoom(String roomId);
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/ClearChatRoomUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/application/usecase/ClearChatRoomUseCase.java
@@ -1,0 +1,27 @@
+package org.giglab.live.commerce.core.campaign.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.core.campaign.application.port.persistence.CampaignStorePort;
+import org.giglab.live.commerce.core.campaign.domain.exception.CampaignDomainException;
+import org.giglab.live.commerce.core.campaign.domain.exception.CampaignErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ClearChatRoomUseCase {
+
+  private final CampaignStorePort campaignStorePort;
+
+  public void execute(Long campaignId) {
+    campaignStorePort
+        .findEntityById(campaignId)
+        .orElseThrow(
+            () ->
+                new CampaignDomainException(
+                    CampaignErrorCode.NOT_FOUND,
+                    String.format("캠페인 ID %d 를 찾을 수 없습니다.", campaignId)))
+        .clearChatRoom();
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/Campaign.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/domain/entity/Campaign.java
@@ -100,6 +100,10 @@ public class Campaign extends AuditedEntity {
     this.chatRoomId = chatRoomId;
   }
 
+  public void clearChatRoom() {
+    this.chatRoomId = null;
+  }
+
   public void end() {
     if (this.status != BroadcastStatusType.ON_AIR) {
       throw new CampaignDomainException(CampaignErrorCode.INVALID_STATUS_CHANGE);

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/client/RestChatServerClient.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/campaign/infrastructure/client/RestChatServerClient.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.giglab.live.commerce.core.campaign.application.port.external.ChatRoomCreatePort;
+import org.giglab.live.commerce.core.campaign.application.port.external.ChatRoomDeletePort;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
@@ -15,7 +16,7 @@ import org.springframework.web.client.RestTemplate;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class RestChatServerClient implements ChatRoomCreatePort {
+public class RestChatServerClient implements ChatRoomCreatePort, ChatRoomDeletePort {
 
   private final RestTemplate restTemplate;
 
@@ -37,6 +38,14 @@ public class RestChatServerClient implements ChatRoomCreatePort {
 
     log.info("채팅방 생성 완료 - roomId={}, title={}", body.data().roomId(), title);
     return body.data().roomId();
+  }
+
+  @Override
+  public void deleteRoom(String roomId) {
+    String url = chatServerUrl + "/api/v1/rooms/" + roomId;
+    restTemplate.exchange(
+        url, HttpMethod.DELETE, HttpEntity.EMPTY, new ParameterizedTypeReference<Void>() {});
+    log.info("채팅방 삭제 완료 - roomId={}", roomId);
   }
 
   private record CreateRoomRequest(String title) {}

--- a/web-client/pages/broadcasts/[id].tsx
+++ b/web-client/pages/broadcasts/[id].tsx
@@ -578,7 +578,8 @@ export default function BroadcastDetail() {
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();
       const data: BroadcastStatusData = json.data;
-      setCampaign((prev) => prev ? { ...prev, status: data.status, endedAt: data.endedAt } : prev);
+      setCampaign((prev) => prev ? { ...prev, status: data.status, endedAt: data.endedAt, chatRoomId: data.chatRoomId ?? null } : prev);
+      if (!data.chatRoomId) disconnect();
     } catch {
       alert('방송 종료에 실패했습니다.');
     } finally {


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
방송 종료 시 live-chat-server의 채팅방을 삭제하는 전체 흐름을 구현합니다. live-chat-server에 `DELETE /api/v1/rooms/{roomId}` API를 추가하고, live-commerce-core의 방송 종료 흐름(`CampaignService.end()`)에서 TX 커밋 후 채팅방 삭제 → chatRoomId 초기화까지 처리합니다.


### Issue
- closes #57


### Why
- 방송 종료 후에도 chat-server에 채팅방이 남아 불필요한 리소스를 점유
- 같은 캠페인으로 재방송 시 orphan 채팅방이 누적되는 문제
- 방송 생성 흐름(`start → createRoom`)과 대칭되는 삭제 흐름 부재


### What
- **live-chat-server**
  - `RoomRepository`에 `deleteById(String roomId)` 인터페이스 추가
  - `RedisRoomRepository`에 `deleteById()` 구현 — `MULTI/EXEC`로 `DEL LIVE:ROOM:{roomId}` + `ZREM LIVE:ROOM:INDEX {roomId}` 원자적 실행
  - `RoomService.deleteRoom()` 추가
  - `RoomController`에 `DELETE /api/v1/rooms/{roomId}` 엔드포인트 추가 (HTTP 204)

- **live-commerce-core**
  - `ChatRoomDeletePort` 아웃바운드 포트 인터페이스 추가
  - `RestChatServerClient`에 `deleteRoom()` 구현 (`ChatRoomDeletePort` implements 추가)
  - `Campaign` 도메인에 `clearChatRoom()` 메서드 추가 (chatRoomId → null)
  - `ClearChatRoomUseCase` 신규 추가 (`@Transactional`, chatRoomId DB 초기화)
  - `CampaignService.end()` — TX1 커밋 후 HTTP 삭제 → TX2 chatRoomId 초기화 오케스트레이션

- **web-client**
  - `handleEnd()` — 종료 응답에서 `chatRoomId`가 null이면 즉시 WebSocket `disconnect()` 호출


### How
- **헥사고날 아키텍처 준수**: `ChatRoomDeletePort` (포트) + `RestChatServerClient` (어댑터) 구조로 외부 HTTP 호출 분리
- **TX 분리 패턴**: `start()` 흐름과 동일하게 적용
  - TX1: `EndCampaignUseCase` — 방송 종료 상태 커밋
  - HTTP: `chatRoomDeletePort.deleteRoom()` — 트랜잭션 외부
  - TX2: `ClearChatRoomUseCase` — chatRoomId null 초기화 커밋
- **장애 방어**: chat-server 삭제 실패 시 `log.warn`만 남기고 방송 종료는 정상 완료 (chatRoomId는 DB에 남아 다음 종료 재시도 가능)
- **Redis 원자적 삭제**: `MULTI/EXEC`로 Room 키와 Sorted Set 인덱스를 동시에 제거 — 인덱스 잔류 방지
- **idempotent 204**: roomId가 이미 없어도 204 반환 — live-commerce-core 재시도 안전


### Test
- 방송 시작 → 채팅 참여 → 방송 종료 버튼 클릭
  - chat-server 로그에서 `채팅방 삭제 완료 - roomId=...` 확인
  - DB `campaigns.chat_room_id` 컬럼 NULL 업데이트 확인
  - 프론트 WebSocket 자동 disconnect 및 입력창 읽기전용 전환 확인
- chat-server 중단 상태에서 방송 종료
  - 방송은 정상 ENDED, `[WARN] 채팅방 삭제 실패` 로그 출력 확인
- 중복 DELETE 호출 (idempotent)
  - `curl -X DELETE http://localhost:8081/api/v1/rooms/{roomId}` 두 번 → 모두 204 확인