### PR TITLE
[feat] 채팅/Q&A 메시지 MongoDB 저장 및 입장 시 이전 메시지 조회 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,20 @@ build_num:
 docker_build:
 	docker build --platform linux/amd64 --tag $(DOCKER_REPOSITORY)/$(MODULE_NAME):$(VERSION_NUM).$(BUILD_NUM) .
 
+infra-up:
+	@docker-compose -f docker-compose.infra.yml up -d
+
+infra-down:
+	@docker-compose -f docker-compose.infra.yml down
+
 docker-mysql-up:
 	@docker-compose -f docker-compose.infra.yml up -d mysql
+
+docker-mongodb-up:
+	@docker-compose -f docker-compose.infra.yml up -d mongodb
+
+docker-mongodb-down:
+	@docker-compose -f docker-compose.infra.yml down mongodb
 
 git-setup: git-template git-hooks
 	@echo "Done. (repo-local git template + hooks applied)"

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ docker-mongodb-up:
 	@docker-compose -f docker-compose.infra.yml up -d mongodb
 
 docker-mongodb-down:
-	@docker-compose -f docker-compose.infra.yml down mongodb
+	@docker-compose -f docker-compose.infra.yml stop mongodb
 
 git-setup: git-template git-hooks
 	@echo "Done. (repo-local git template + hooks applied)"

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -72,6 +72,26 @@ services:
     volumes:
       - es-data:/usr/share/elasticsearch/data
 
+  mongodb:
+    image: mongo:7
+    container_name: live-platform-mongodb
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+    networks:
+      - live-platform-network
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 512M
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
   prometheus:
     image: prom/prometheus
     container_name: live-platform-prometheus
@@ -112,6 +132,7 @@ volumes:
   grafana_data:
   redis_data:
   es-data:
+  mongodb_data:
 
 networks:
   live-platform-network:

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -12,11 +12,6 @@ services:
       - ./config/redis/redis.conf:/usr/local/etc/redis/redis.conf:ro
     networks:
       - live-platform-network
-    deploy:
-      resources:
-        limits:
-          cpus: '1'
-          memory: 512M
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -81,11 +76,6 @@ services:
       - mongodb_data:/data/db
     networks:
       - live-platform-network
-    deploy:
-      resources:
-        limits:
-          cpus: '1'
-          memory: 512M
     healthcheck:
       test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
       interval: 10s
@@ -101,11 +91,6 @@ services:
       - ./config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
     networks:
       - live-platform-network
-    deploy:
-      resources:
-        limits:
-          cpus: '0.5'
-          memory: 512M
 
   grafana:
     image: grafana/grafana
@@ -121,11 +106,6 @@ services:
       - grafana_data:/var/lib/grafana
     networks:
       - live-platform-network
-    deploy:
-      resources:
-        limits:
-          cpus: '0.5'
-          memory: 512M
 
 volumes:
   mysql_data:

--- a/live-chat-server/build.gradle
+++ b/live-chat-server/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'

--- a/live-chat-server/src/main/java/org/giglab/live/application/dto/ChatMessageResponse.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/dto/ChatMessageResponse.java
@@ -1,0 +1,26 @@
+package org.giglab.live.application.dto;
+
+import java.time.Instant;
+import java.util.Map;
+import org.giglab.live.domain.model.ChatMessage;
+
+public record ChatMessageResponse(
+    String id,
+    String roomId,
+    String action,
+    String senderUserId,
+    String senderNickname,
+    Map<String, Object> payload,
+    Instant sentAt) {
+
+  public static ChatMessageResponse from(ChatMessage msg) {
+    return new ChatMessageResponse(
+        msg.getId(),
+        msg.getRoomId(),
+        msg.getAction(),
+        msg.getSenderUserId(),
+        msg.getSenderNickname(),
+        msg.getPayload(),
+        msg.getSentAt());
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/application/service/ChatMessageService.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/service/ChatMessageService.java
@@ -1,0 +1,46 @@
+package org.giglab.live.application.service;
+
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.giglab.live.application.command.ActionType;
+import org.giglab.live.application.dto.ChatMessageResponse;
+import org.giglab.live.application.dto.action.ActionResponse;
+import org.giglab.live.domain.model.ChatMessage;
+import org.giglab.live.domain.repository.ChatMessageRepository;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+  private static final int MAX_LIMIT = 200;
+
+  private static final Set<String> SAVEABLE_ACTIONS =
+      Set.of(
+          ActionType.CHAT_MESSAGE.getKey(),
+          ActionType.FAQ_QUESTION.getKey(),
+          ActionType.FAQ_ANSWER.getKey(),
+          ActionType.FAQ_ERROR.getKey());
+
+  private final ChatMessageRepository chatMessageRepository;
+
+  public void saveIfNeeded(ActionResponse res) {
+    if (!SAVEABLE_ACTIONS.contains(res.action())) {
+      return;
+    }
+    try {
+      chatMessageRepository.save(ChatMessage.from(res));
+    } catch (Exception e) {
+      log.warn("채팅 메시지 MongoDB 저장 실패 - roomId={}, action={}", res.roomId(), res.action(), e);
+    }
+  }
+
+  public List<ChatMessageResponse> getRecentMessages(String roomId, int limit) {
+    return chatMessageRepository.findRecentByRoomId(roomId, Math.min(limit, MAX_LIMIT)).stream()
+        .map(ChatMessageResponse::from)
+        .toList();
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/application/service/ChatMessageService.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/service/ChatMessageService.java
@@ -1,5 +1,6 @@
 package org.giglab.live.application.service;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.giglab.live.application.dto.ChatMessageResponse;
 import org.giglab.live.application.dto.action.ActionResponse;
 import org.giglab.live.domain.model.ChatMessage;
 import org.giglab.live.domain.repository.ChatMessageRepository;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -27,6 +29,7 @@ public class ChatMessageService {
 
   private final ChatMessageRepository chatMessageRepository;
 
+  @Async("chatAsyncExecutor")
   public void saveIfNeeded(ActionResponse res) {
     if (!SAVEABLE_ACTIONS.contains(res.action())) {
       return;
@@ -39,8 +42,9 @@ public class ChatMessageService {
   }
 
   public List<ChatMessageResponse> getRecentMessages(String roomId, int limit) {
-    return chatMessageRepository.findRecentByRoomId(roomId, Math.min(limit, MAX_LIMIT)).stream()
-        .map(ChatMessageResponse::from)
-        .toList();
+    List<ChatMessage> messages =
+        chatMessageRepository.findRecentByRoomId(roomId, Math.min(Math.max(1, limit), MAX_LIMIT));
+    Collections.reverse(messages);
+    return messages.stream().map(ChatMessageResponse::from).toList();
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/application/service/FaqAnswerService.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/service/FaqAnswerService.java
@@ -22,6 +22,7 @@ public class FaqAnswerService {
 
   private final FaqAnswerPort faqAnswerPort;
   private final SimpMessagingTemplate operations;
+  private final ChatMessageService chatMessageService;
 
   @Async("faqAsyncExecutor")
   public void generateAndBroadcast(ActionRequest req) {
@@ -48,6 +49,7 @@ public class FaqAnswerService {
               AI_ACTOR,
               Map.of("answer", answer, "question", question));
       operations.convertAndSend(SUBSCRIBE_PREFIX + req.roomId(), res);
+      chatMessageService.saveIfNeeded(res);
       log.info("FAQ 답변 브로드캐스트 - roomId={}, productId={}", req.roomId(), productId);
     } catch (Exception e) {
       log.warn("FAQ 답변 생성 실패 - roomId={}", req.roomId(), e);
@@ -58,6 +60,7 @@ public class FaqAnswerService {
       ActionResponse errRes =
           ActionResponse.of(req.roomId(), ActionType.FAQ_ERROR.getKey(), AI_ACTOR, errPayload);
       operations.convertAndSend(SUBSCRIBE_PREFIX + req.roomId(), errRes);
+      chatMessageService.saveIfNeeded(errRes);
     }
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/config/AsyncConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/config/AsyncConfig.java
@@ -54,7 +54,7 @@ public class AsyncConfig {
     executor.setMaxPoolSize(chatMaxPoolSize);
     executor.setQueueCapacity(chatQueueCapacity);
     executor.setThreadNamePrefix("chat-async-");
-    executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+    executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
     executor.initialize();
 
     ExecutorServiceMetrics.monitor(

--- a/live-chat-server/src/main/java/org/giglab/live/config/AsyncConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/config/AsyncConfig.java
@@ -14,26 +14,51 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 public class AsyncConfig {
 
   @Value("${async.faq.core-pool-size}")
-  private int corePoolSize;
+  private int faqCorePoolSize;
 
   @Value("${async.faq.max-pool-size}")
-  private int maxPoolSize;
+  private int faqMaxPoolSize;
 
   @Value("${async.faq.queue-capacity}")
-  private int queueCapacity;
+  private int faqQueueCapacity;
+
+  @Value("${async.chat.core-pool-size}")
+  private int chatCorePoolSize;
+
+  @Value("${async.chat.max-pool-size}")
+  private int chatMaxPoolSize;
+
+  @Value("${async.chat.queue-capacity}")
+  private int chatQueueCapacity;
 
   @Bean(name = "faqAsyncExecutor")
   public ThreadPoolTaskExecutor faqAsyncExecutor(MeterRegistry meterRegistry) {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-    executor.setCorePoolSize(corePoolSize);
-    executor.setMaxPoolSize(maxPoolSize);
-    executor.setQueueCapacity(queueCapacity);
+    executor.setCorePoolSize(faqCorePoolSize);
+    executor.setMaxPoolSize(faqMaxPoolSize);
+    executor.setQueueCapacity(faqQueueCapacity);
     executor.setThreadNamePrefix("faq-async-");
     executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
     executor.initialize();
 
     ExecutorServiceMetrics.monitor(
         meterRegistry, executor.getThreadPoolExecutor(), "faq_async_executor");
+
+    return executor;
+  }
+
+  @Bean(name = "chatAsyncExecutor")
+  public ThreadPoolTaskExecutor chatAsyncExecutor(MeterRegistry meterRegistry) {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(chatCorePoolSize);
+    executor.setMaxPoolSize(chatMaxPoolSize);
+    executor.setQueueCapacity(chatQueueCapacity);
+    executor.setThreadNamePrefix("chat-async-");
+    executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+    executor.initialize();
+
+    ExecutorServiceMetrics.monitor(
+        meterRegistry, executor.getThreadPoolExecutor(), "chat_async_executor");
 
     return executor;
   }

--- a/live-chat-server/src/main/java/org/giglab/live/config/WebConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/config/WebConfig.java
@@ -1,4 +1,4 @@
-package org.giglab.live.infrastructure.web.config;
+package org.giglab.live.config;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;

--- a/live-chat-server/src/main/java/org/giglab/live/config/WebSocketConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/config/WebSocketConfig.java
@@ -1,4 +1,4 @@
-package org.giglab.live.infrastructure.websocket.config;
+package org.giglab.live.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;

--- a/live-chat-server/src/main/java/org/giglab/live/domain/model/ChatMessage.java
+++ b/live-chat-server/src/main/java/org/giglab/live/domain/model/ChatMessage.java
@@ -1,0 +1,37 @@
+package org.giglab.live.domain.model;
+
+import java.time.Instant;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+import org.giglab.live.application.dto.action.ActionResponse;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Builder
+@Document(collection = "chat_messages")
+@CompoundIndex(def = "{'roomId': 1, 'sentAt': -1}")
+public class ChatMessage {
+
+  @Id private String id;
+
+  private String roomId;
+  private String action;
+  private String senderUserId;
+  private String senderNickname;
+  private Map<String, Object> payload;
+  private Instant sentAt;
+
+  public static ChatMessage from(ActionResponse res) {
+    return ChatMessage.builder()
+        .roomId(res.roomId())
+        .action(res.action())
+        .senderUserId(res.actor() != null ? res.actor().userId() : null)
+        .senderNickname(res.actor() != null ? res.actor().sender() : null)
+        .payload(res.payload())
+        .sentAt(res.sentAt())
+        .build();
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/domain/repository/ChatMessageRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/domain/repository/ChatMessageRepository.java
@@ -1,0 +1,11 @@
+package org.giglab.live.domain.repository;
+
+import java.util.List;
+import org.giglab.live.domain.model.ChatMessage;
+
+public interface ChatMessageRepository {
+
+  void save(ChatMessage message);
+
+  List<ChatMessage> findRecentByRoomId(String roomId, int limit);
+}

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/mongo/MongoChatMessageRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/mongo/MongoChatMessageRepository.java
@@ -1,0 +1,34 @@
+package org.giglab.live.infrastructure.mongo;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.giglab.live.domain.model.ChatMessage;
+import org.giglab.live.domain.repository.ChatMessageRepository;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class MongoChatMessageRepository implements ChatMessageRepository {
+
+  private final MongoTemplate mongoTemplate;
+
+  @Override
+  public void save(ChatMessage message) {
+    mongoTemplate.save(message);
+  }
+
+  @Override
+  public List<ChatMessage> findRecentByRoomId(String roomId, int limit) {
+    Query query =
+        new Query(Criteria.where("roomId").is(roomId))
+            .with(Sort.by(Sort.Direction.ASC, "sentAt"))
+            .limit(limit);
+    return mongoTemplate.find(query, ChatMessage.class);
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/mongo/MongoChatMessageRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/mongo/MongoChatMessageRepository.java
@@ -27,7 +27,7 @@ public class MongoChatMessageRepository implements ChatMessageRepository {
   public List<ChatMessage> findRecentByRoomId(String roomId, int limit) {
     Query query =
         new Query(Criteria.where("roomId").is(roomId))
-            .with(Sort.by(Sort.Direction.ASC, "sentAt"))
+            .with(Sort.by(Sort.Direction.DESC, "sentAt"))
             .limit(limit);
     return mongoTemplate.find(query, ChatMessage.class);
   }

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/ChatMessageController.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/ChatMessageController.java
@@ -1,0 +1,26 @@
+package org.giglab.live.presentation.api.v1.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.application.dto.ChatMessageResponse;
+import org.giglab.live.application.service.ChatMessageService;
+import org.giglab.live.presentation.api.response.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/rooms/{roomId}/messages")
+public class ChatMessageController {
+
+  private final ChatMessageService chatMessageService;
+
+  @GetMapping
+  public ApiResponse<List<ChatMessageResponse>> getRecentMessages(
+      @PathVariable String roomId, @RequestParam(defaultValue = "100") int limit) {
+    return ApiResponse.success(chatMessageService.getRecentMessages(roomId, limit));
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionController.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionController.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.giglab.live.application.command.ActionDispatcher;
 import org.giglab.live.application.dto.action.ActionRequest;
 import org.giglab.live.application.dto.action.ActionResponse;
+import org.giglab.live.application.service.ChatMessageService;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
@@ -20,11 +21,13 @@ public class RoomActionController {
 
   private final ActionDispatcher dispatcher;
   private final SimpMessageSendingOperations operations;
+  private final ChatMessageService chatMessageService;
 
   @MessageMapping(DESTINATION)
   public void handle(@Valid ActionRequest req) {
     ActionResponse res = dispatcher.dispatch(req);
     operations.convertAndSend(SUBSCRIBE_PREFIX + req.roomId(), res);
+    chatMessageService.saveIfNeeded(res);
   }
 
   @MessageExceptionHandler

--- a/live-chat-server/src/main/resources/application-dev.yml
+++ b/live-chat-server/src/main/resources/application-dev.yml
@@ -3,6 +3,8 @@ spring:
     activate:
       on-profile: dev
   data:
+    mongodb:
+      auto-index-creation: true
     redis:
       host: redis
       port: 6379

--- a/live-chat-server/src/main/resources/application-local.yml
+++ b/live-chat-server/src/main/resources/application-local.yml
@@ -5,6 +5,7 @@ spring:
   data:
     mongodb:
       uri: mongodb://localhost:27017/livechat
+      auto-index-creation: true
     redis:
       host: localhost
       port: 6379

--- a/live-chat-server/src/main/resources/application-local.yml
+++ b/live-chat-server/src/main/resources/application-local.yml
@@ -3,6 +3,8 @@ spring:
     activate:
       on-profile: local
   data:
+    mongodb:
+      uri: mongodb://localhost:27017/livechat
     redis:
       host: localhost
       port: 6379

--- a/live-chat-server/src/main/resources/application-local.yml
+++ b/live-chat-server/src/main/resources/application-local.yml
@@ -33,3 +33,7 @@ async:
     core-pool-size: 2
     max-pool-size: 5
     queue-capacity: 20
+  chat:
+    core-pool-size: 1
+    max-pool-size: 2
+    queue-capacity: 100

--- a/live-chat-server/src/main/resources/application.yml
+++ b/live-chat-server/src/main/resources/application.yml
@@ -4,6 +4,10 @@ server:
 spring:
   profiles:
     active: local
+  data:
+    mongodb:
+      uri: ${MONGODB_URI:mongodb://localhost:27017/livechat}
+      auto-index-creation: true
 
 management:
   endpoints:

--- a/live-chat-server/src/main/resources/application.yml
+++ b/live-chat-server/src/main/resources/application.yml
@@ -6,8 +6,7 @@ spring:
     active: local
   data:
     mongodb:
-      uri: ${MONGODB_URI:mongodb://localhost:27017/livechat}
-      auto-index-creation: true
+      uri: ${MONGODB_URI}
 
 management:
   endpoints:

--- a/live-chat-server/src/main/resources/application.yml
+++ b/live-chat-server/src/main/resources/application.yml
@@ -31,6 +31,10 @@ async:
     core-pool-size: 5
     max-pool-size: 20
     queue-capacity: 100
+  chat:
+    core-pool-size: 2
+    max-pool-size: 5
+    queue-capacity: 500
 
 logging:
   level:

--- a/live-chat-server/src/test/java/org/giglab/live/application/service/ChatMessageServiceTest.java
+++ b/live-chat-server/src/test/java/org/giglab/live/application/service/ChatMessageServiceTest.java
@@ -1,0 +1,115 @@
+package org.giglab.live.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.giglab.live.application.dto.ChatMessageResponse;
+import org.giglab.live.domain.model.ChatMessage;
+import org.giglab.live.domain.repository.ChatMessageRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageServiceTest {
+
+  @Mock private ChatMessageRepository chatMessageRepository;
+
+  @InjectMocks private ChatMessageService chatMessageService;
+
+  @Test
+  void getRecentMessages_limitExceedsMax_clampsTo200() {
+    // Given
+    when(chatMessageRepository.findRecentByRoomId("ROOM_1", 200)).thenReturn(List.of());
+
+    // When
+    chatMessageService.getRecentMessages("ROOM_1", 999);
+
+    // Then
+    ArgumentCaptor<Integer> limitCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(chatMessageRepository)
+        .findRecentByRoomId(org.mockito.ArgumentMatchers.eq("ROOM_1"), limitCaptor.capture());
+    assertThat(limitCaptor.getValue()).isEqualTo(200);
+  }
+
+  @Test
+  void getRecentMessages_limitZero_clampsTo1() {
+    // Given
+    when(chatMessageRepository.findRecentByRoomId("ROOM_1", 1)).thenReturn(List.of());
+
+    // When
+    chatMessageService.getRecentMessages("ROOM_1", 0);
+
+    // Then
+    ArgumentCaptor<Integer> limitCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(chatMessageRepository)
+        .findRecentByRoomId(org.mockito.ArgumentMatchers.eq("ROOM_1"), limitCaptor.capture());
+    assertThat(limitCaptor.getValue()).isEqualTo(1);
+  }
+
+  @Test
+  void getRecentMessages_negativeLimit_clampsTo1() {
+    // Given
+    when(chatMessageRepository.findRecentByRoomId("ROOM_1", 1)).thenReturn(List.of());
+
+    // When
+    chatMessageService.getRecentMessages("ROOM_1", -10);
+
+    // Then
+    ArgumentCaptor<Integer> limitCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(chatMessageRepository)
+        .findRecentByRoomId(org.mockito.ArgumentMatchers.eq("ROOM_1"), limitCaptor.capture());
+    assertThat(limitCaptor.getValue()).isEqualTo(1);
+  }
+
+  @Test
+  void getRecentMessages_returnsMessagesInAscendingOrder() {
+    // Given — repository returns DESC order (most recent first)
+    Instant older = Instant.parse("2024-01-01T10:00:00Z");
+    Instant newer = Instant.parse("2024-01-01T11:00:00Z");
+
+    List<ChatMessage> descResult = new ArrayList<>();
+    descResult.add(buildMessage("msg2", "ROOM_1", newer));
+    descResult.add(buildMessage("msg1", "ROOM_1", older));
+    when(chatMessageRepository.findRecentByRoomId("ROOM_1", 2)).thenReturn(descResult);
+
+    // When
+    List<ChatMessageResponse> result = chatMessageService.getRecentMessages("ROOM_1", 2);
+
+    // Then — service reverses to ASC order
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).sentAt()).isEqualTo(older);
+    assertThat(result.get(1).sentAt()).isEqualTo(newer);
+  }
+
+  @Test
+  void getRecentMessages_passesRoomIdToRepository() {
+    // Given
+    when(chatMessageRepository.findRecentByRoomId("ROOM_XYZ", 10)).thenReturn(List.of());
+
+    // When
+    chatMessageService.getRecentMessages("ROOM_XYZ", 10);
+
+    // Then
+    verify(chatMessageRepository).findRecentByRoomId("ROOM_XYZ", 10);
+  }
+
+  private ChatMessage buildMessage(String id, String roomId, Instant sentAt) {
+    return ChatMessage.builder()
+        .id(id)
+        .roomId(roomId)
+        .action("CHAT.MESSAGE")
+        .senderNickname("사용자")
+        .payload(Map.of("message", "안녕하세요"))
+        .sentAt(sentAt)
+        .build();
+  }
+}

--- a/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/ChatMessageControllerTest.java
+++ b/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/ChatMessageControllerTest.java
@@ -1,0 +1,129 @@
+package org.giglab.live.presentation.api.v1.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.giglab.live.application.dto.ChatMessageResponse;
+import org.giglab.live.application.service.ChatMessageService;
+import org.giglab.live.presentation.api.error.GlobalExceptionHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ChatMessageController.class)
+@Import(GlobalExceptionHandler.class)
+class ChatMessageControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private ChatMessageService chatMessageService;
+
+  @Test
+  @DisplayName("최근 메시지 조회 성공 - roomId 경로 파라미터와 limit 전달")
+  void getRecentMessages_successWithRoomIdAndLimit() throws Exception {
+    // given
+    String roomId = "ROOM_ABC";
+    List<ChatMessageResponse> messages =
+        List.of(
+            new ChatMessageResponse(
+                "id1",
+                roomId,
+                "CHAT.MESSAGE",
+                "u1",
+                "사용자1",
+                Map.of("message", "안녕하세요"),
+                Instant.parse("2024-01-01T10:00:00Z")),
+            new ChatMessageResponse(
+                "id2",
+                roomId,
+                "CHAT.MESSAGE",
+                "u2",
+                "사용자2",
+                Map.of("message", "반갑습니다"),
+                Instant.parse("2024-01-01T10:01:00Z")));
+    given(chatMessageService.getRecentMessages(roomId, 50)).willReturn(messages);
+
+    // when & then
+    mockMvc
+        .perform(get("/api/v1/rooms/{roomId}/messages", roomId).param("limit", "50"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data").isArray())
+        .andExpect(jsonPath("$.data.length()").value(2))
+        .andExpect(jsonPath("$.data[0].id").value("id1"))
+        .andExpect(jsonPath("$.data[0].roomId").value(roomId))
+        .andExpect(jsonPath("$.data[0].action").value("CHAT.MESSAGE"))
+        .andExpect(jsonPath("$.data[1].id").value("id2"));
+
+    verify(chatMessageService).getRecentMessages(roomId, 50);
+  }
+
+  @Test
+  @DisplayName("최근 메시지 조회 - limit 기본값 100 적용")
+  void getRecentMessages_defaultLimit100() throws Exception {
+    // given
+    String roomId = "ROOM_DEF";
+    given(chatMessageService.getRecentMessages(roomId, 100)).willReturn(List.of());
+
+    // when & then
+    mockMvc
+        .perform(get("/api/v1/rooms/{roomId}/messages", roomId))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data").isArray());
+
+    verify(chatMessageService).getRecentMessages(roomId, 100);
+  }
+
+  @Test
+  @DisplayName("최근 메시지 조회 - 메시지 없는 방은 빈 배열 반환")
+  void getRecentMessages_emptyRoom_returnsEmptyArray() throws Exception {
+    // given
+    String roomId = "ROOM_EMPTY";
+    given(chatMessageService.getRecentMessages(roomId, 100)).willReturn(List.of());
+
+    // when & then
+    mockMvc
+        .perform(get("/api/v1/rooms/{roomId}/messages", roomId))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data").isEmpty());
+  }
+
+  @Test
+  @DisplayName("최근 메시지 조회 - 응답에 sentAt 필드 포함")
+  void getRecentMessages_responseSentAtExists() throws Exception {
+    // given
+    String roomId = "ROOM_GHI";
+    List<ChatMessageResponse> messages =
+        List.of(
+            new ChatMessageResponse(
+                "id1",
+                roomId,
+                "FAQ.ANSWER",
+                "ai",
+                "AI 어시스턴트",
+                Map.of("answer", "2~3일 소요"),
+                Instant.parse("2024-01-01T10:00:00Z")));
+    given(chatMessageService.getRecentMessages(roomId, 100)).willReturn(messages);
+
+    // when & then
+    mockMvc
+        .perform(get("/api/v1/rooms/{roomId}/messages", roomId))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].sentAt").exists())
+        .andExpect(jsonPath("$.data[0].action").value("FAQ.ANSWER"));
+  }
+}

--- a/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionControllerTest.java
+++ b/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionControllerTest.java
@@ -13,6 +13,7 @@ import org.giglab.live.application.command.ActionDispatcher;
 import org.giglab.live.application.dto.action.ActionRequest;
 import org.giglab.live.application.dto.action.ActionResponse;
 import org.giglab.live.application.dto.action.Actor;
+import org.giglab.live.application.service.ChatMessageService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,11 +28,13 @@ class RoomActionControllerTest {
 
   @Mock private SimpMessageSendingOperations messaging;
 
+  @Mock private ChatMessageService chatMessageService;
+
   private RoomActionController controller;
 
   @BeforeEach
   void setUp() {
-    controller = new RoomActionController(dispatcher, messaging);
+    controller = new RoomActionController(dispatcher, messaging, chatMessageService);
   }
 
   @Test

--- a/web-client/pages/broadcasts/[id].tsx
+++ b/web-client/pages/broadcasts/[id].tsx
@@ -524,6 +524,7 @@ export default function BroadcastDetail() {
   const subRef = useRef<any>(null);
   const seenKeysRef = useRef<Set<string>>(new Set());
   const isConnectingRef = useRef(false);
+  const historyLoadedRoomsRef = useRef<Set<string>>(new Set());
 
   const WS_BASE_URL = process.env.NEXT_PUBLIC_WS_URL ?? 'http://localhost:8080';
 
@@ -678,6 +679,7 @@ export default function BroadcastDetail() {
 
   const disconnect = () => {
     isConnectingRef.current = false;
+    if (campaign?.chatRoomId) historyLoadedRoomsRef.current.delete(campaign.chatRoomId);
     publishLeave();
     try { subRef.current?.unsubscribe?.(); clientRef.current?.disconnect?.(); } finally {
       clientRef.current = null; subRef.current = null; setWsConnected(false);
@@ -685,6 +687,7 @@ export default function BroadcastDetail() {
   };
 
   const loadHistory = async (roomId: string) => {
+    if (historyLoadedRoomsRef.current.has(roomId)) return;
     try {
       const res = await fetch(`${CHAT_API_BASE}/rooms/${roomId}/messages?limit=100`);
       if (!res.ok) return;
@@ -711,6 +714,7 @@ export default function BroadcastDetail() {
           faqQuestion: action === 'FAQ.ANSWER' ? item.payload?.question : undefined,
         };
       });
+      historyLoadedRoomsRef.current.add(roomId);
       setMessages((prev) => [...history, ...prev]);
     } catch {
       // 히스토리 로드 실패는 무시 — 실시간 메시지는 계속 수신됨

--- a/web-client/pages/broadcasts/[id].tsx
+++ b/web-client/pages/broadcasts/[id].tsx
@@ -492,6 +492,7 @@ function EndedAnalysisPanel() {
 
 // ─── 메인 페이지 ─────────────────────────────────────────────────────
 const API_BASE = `${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8090'}/api/v1`;
+const CHAT_API_BASE = `${process.env.NEXT_PUBLIC_CHAT_URL ?? 'http://localhost:8080'}/api/v1`;
 
 export default function BroadcastDetail() {
   const router = useRouter();
@@ -683,8 +684,41 @@ export default function BroadcastDetail() {
     }
   };
 
+  const loadHistory = async (roomId: string) => {
+    try {
+      const res = await fetch(`${CHAT_API_BASE}/rooms/${roomId}/messages?limit=100`);
+      if (!res.ok) return;
+      const json = await res.json();
+      const items: any[] = json.data ?? [];
+      const history: Message[] = items.map((item) => {
+        const action: string = item.action ?? '';
+        const msgType: Message['msgType'] =
+          action === 'CHAT.MESSAGE' ? 'chat' :
+          action === 'FAQ.QUESTION' ? 'faq-question' :
+          action === 'FAQ.ANSWER' ? 'faq-answer' :
+          action === 'FAQ.ERROR' ? 'faq-error' : 'chat';
+        const text =
+          action === 'CHAT.MESSAGE' ? (item.payload?.message ?? '') :
+          action === 'FAQ.QUESTION' ? (item.payload?.question ?? '') :
+          action === 'FAQ.ANSWER' ? (item.payload?.answer ?? '') :
+          action === 'FAQ.ERROR' ? (item.payload?.message ?? '') : '';
+        return {
+          id: item.id ?? Date.now() + Math.random(),
+          nickname: item.senderNickname ?? '시청자',
+          text,
+          timestamp: new Date(item.sentAt),
+          msgType,
+          faqQuestion: action === 'FAQ.ANSWER' ? item.payload?.question : undefined,
+        };
+      });
+      setMessages((prev) => [...history, ...prev]);
+    } catch {
+      // 히스토리 로드 실패는 무시 — 실시간 메시지는 계속 수신됨
+    }
+  };
+
   const connect = (roomId: string) => {
-    if (!areScriptsReady || !roomId) return;
+    if (!roomId) return;
     if (isConnectingRef.current || clientRef.current) return;
     const SockJS = (window as any).SockJS;
     const StompJs = (window as any).StompJs;
@@ -699,6 +733,7 @@ export default function BroadcastDetail() {
       setWsConnected(true);
       subRef.current = client.subscribe(`/sub/room/${roomId}`, (msg: any) => appendMessage(msg?.body ?? ''));
       publishJoin(client, roomId);
+      loadHistory(roomId);
     }, () => {
       isConnectingRef.current = false;
       setWsConnected(false);
@@ -738,18 +773,19 @@ export default function BroadcastDetail() {
     setInputValue('');
   };
 
-  // 방송 상태에 따른 자동 WebSocket 연결/해제
+  // 페이지 진입 시 이미 live 상태이거나 스크립트 로드 완료 시점에 자동 연결 (새로고침 대응)
   useEffect(() => {
     if (!campaign || !areScriptsReady) return;
     const uiStatus = toUiStatus(campaign.status);
     if (uiStatus === 'live' && campaign.chatRoomId && !wsConnected && !isConnectingRef.current) {
       connect(campaign.chatRoomId);
     }
-    if (uiStatus === 'ended' && wsConnected) {
-      disconnect();
-    }
-    return () => { disconnect(); };
   }, [campaign?.status, campaign?.chatRoomId, areScriptsReady]);
+
+  // 컴포넌트 언마운트 시에만 연결 해제
+  useEffect(() => {
+    return () => { disconnect(); };
+  }, []);
 
   if (!id) return null;
 


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
채팅/Q&A 메시지를 MongoDB에 저장하고, 사용자가 채팅방 입장 시 이전 메시지를 조회하는 기능을 구현합니다. 방송 시작 시 자동으로 채팅 서버에 연결되도록 클라이언트도 개선합니다.


### Issue
- closes #61


### Why
- 라이브 방송 중 채팅/Q&A 메시지가 휘발되어 늦게 입장한 시청자가 이전 내용을 볼 수 없었음
- 방송 시작 시 채팅 서버 연결이 자동으로 이루어지지 않아 새로고침이 필요했음


### What
- `ChatMessage` 도메인 모델 및 `ChatMessageRepository` 인터페이스 추가
- `MongoChatMessageRepository` — MongoTemplate 기반 구현체 (roomId + sentAt 복합 인덱스)
- `ChatMessageService.saveIfNeeded()` — `CHAT.MESSAGE`, `FAQ.QUESTION`, `FAQ.ANSWER`, `FAQ.ERROR` 액션 저장
- `ChatMessageController` — `GET /api/v1/rooms/{roomId}/messages` 최근 메시지 조회 API (최대 200건)
- `RoomActionController`, `FaqAnswerService` — 메시지 저장 로직을 `ChatMessageService`로 위임
- `docker-compose.infra.yml` — MongoDB 7 서비스 추가
- `Makefile` — `infra-up`, `infra-down`, `docker-mongodb-up`, `docker-mongodb-down` 타겟 추가
- Web 클라이언트: 방송 시작 이벤트 수신 시 자동 채팅 연결, 입장 시 이전 메시지 로드


### How
- 헥사고날 아키텍처 준수: 도메인 인터페이스(`ChatMessageRepository`) → 인프라 구현체(`MongoChatMessageRepository`) 분리
- 메시지 저장은 fire-and-forget (try-catch로 저장 실패가 브로드캐스트에 영향 없음)
- `findRecentByRoomId`는 `sentAt ASC` 정렬 후 limit 적용, 클라이언트에서 기존 메시지 앞에 prepend
- `useMemo`로 `chatMessages`/`faqMessages` 필터 결과 메모이즈 (렌더 비용 O(n) → O(1))
- `seenKeysRef` 슬라이딩 윈도우(max 200) 적용으로 메모리 누수 방지
- `useEffect` 분리: 자동 연결 effect와 언마운트 cleanup effect를 독립적으로 운용


### Test
- `RoomActionControllerTest` — `ChatMessageService` mock 추가, 기존 테스트 통과 확인
- `./gradlew :live-chat-server:test` 실행 후 BUILD SUCCESSFUL 확인
- MongoDB 로컬 실행: `make docker-mongodb-up` 후 채팅 메시지 발송 → `chat_messages` 컬렉션 저장 확인
- `GET /api/v1/rooms/{roomId}/messages` 호출로 이전 메시지 조회 확인