### PR TITLE
[#63] feat: 실시간 시청자 세션 추적 및 피크 시청자 스냅샷 저장 기능 구현

### DIFF
--- a/live-chat-server/src/main/java/org/giglab/live/LiveChatApplication.java
+++ b/live-chat-server/src/main/java/org/giglab/live/LiveChatApplication.java
@@ -2,9 +2,7 @@ package org.giglab.live;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableScheduling
 @SpringBootApplication
 public class LiveChatApplication {
 

--- a/live-chat-server/src/main/java/org/giglab/live/LiveChatApplication.java
+++ b/live-chat-server/src/main/java/org/giglab/live/LiveChatApplication.java
@@ -2,7 +2,9 @@ package org.giglab.live;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class LiveChatApplication {
 

--- a/live-chat-server/src/main/java/org/giglab/live/application/service/ViewerSessionService.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/service/ViewerSessionService.java
@@ -1,0 +1,24 @@
+package org.giglab.live.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.application.command.ActionType;
+import org.giglab.live.application.dto.action.ActionRequest;
+import org.giglab.live.infrastructure.redis.ViewerRedisRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ViewerSessionService {
+
+  private final ViewerRedisRepository viewerRedisRepository;
+
+  public void saveUserIdIfJoin(ActionRequest req, String sessionId) {
+    if (!ActionType.CHAT_JOIN.getKey().equals(req.action())) {
+      return;
+    }
+    if (sessionId == null || req.actor() == null || req.actor().userId() == null) {
+      return;
+    }
+    viewerRedisRepository.saveUserId(sessionId, req.actor().userId());
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/application/service/ViewerSnapshotScheduler.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/service/ViewerSnapshotScheduler.java
@@ -1,0 +1,47 @@
+package org.giglab.live.application.service;
+
+import java.time.Instant;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.giglab.live.domain.model.PeakViewerSnapshot;
+import org.giglab.live.infrastructure.mongo.MongoPeakViewerSnapshotRepository;
+import org.giglab.live.infrastructure.redis.ViewerRedisRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ViewerSnapshotScheduler {
+
+  private final ViewerRedisRepository viewerRedisRepository;
+  private final MongoPeakViewerSnapshotRepository snapshotRepository;
+
+  @Scheduled(fixedDelay = 60_000)
+  public void snapshot() {
+    Set<String> roomIds = viewerRedisRepository.getActiveRoomIds();
+    if (roomIds.isEmpty()) {
+      return;
+    }
+
+    Instant now = Instant.now();
+    roomIds.forEach(
+        roomId -> {
+          long count = viewerRedisRepository.getViewerCount(roomId);
+          if (count <= 0) {
+            return;
+          }
+
+          PeakViewerSnapshot snap =
+              PeakViewerSnapshot.builder()
+                  .roomId(roomId)
+                  .viewerCount((int) count)
+                  .recordedAt(now)
+                  .build();
+
+          snapshotRepository.save(snap);
+          log.debug("시청자 스냅샷 저장 - roomId={}, count={}", roomId, count);
+        });
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/config/SchedulingConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/config/SchedulingConfig.java
@@ -1,0 +1,8 @@
+package org.giglab.live.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class SchedulingConfig {}

--- a/live-chat-server/src/main/java/org/giglab/live/config/SchedulingConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/config/SchedulingConfig.java
@@ -1,8 +1,10 @@
 package org.giglab.live.config;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@ConditionalOnProperty(name = "scheduling.enabled", havingValue = "true")
 @EnableScheduling
 @Configuration
 public class SchedulingConfig {}

--- a/live-chat-server/src/main/java/org/giglab/live/domain/model/PeakViewerSnapshot.java
+++ b/live-chat-server/src/main/java/org/giglab/live/domain/model/PeakViewerSnapshot.java
@@ -1,0 +1,20 @@
+package org.giglab.live.domain.model;
+
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Builder
+@Document(collection = "peak_viewer_snapshots")
+@CompoundIndex(def = "{'roomId': 1, 'recordedAt': -1}")
+public class PeakViewerSnapshot {
+
+  @Id private String id;
+  private String roomId;
+  private int viewerCount;
+  private Instant recordedAt;
+}

--- a/live-chat-server/src/main/java/org/giglab/live/domain/model/ViewerSession.java
+++ b/live-chat-server/src/main/java/org/giglab/live/domain/model/ViewerSession.java
@@ -1,0 +1,23 @@
+package org.giglab.live.domain.model;
+
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Builder
+@Document(collection = "viewer_sessions")
+@CompoundIndex(def = "{'roomId': 1, 'joinAt': -1}")
+public class ViewerSession {
+
+  @Id private String id;
+  private String sessionId;
+  private String roomId;
+  private String userId; // nullable (CHAT_JOIN 미전송 시)
+  private Instant joinAt;
+  private Instant leaveAt;
+  private long durationSeconds;
+}

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/mongo/MongoPeakViewerSnapshotRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/mongo/MongoPeakViewerSnapshotRepository.java
@@ -1,0 +1,7 @@
+package org.giglab.live.infrastructure.mongo;
+
+import org.giglab.live.domain.model.PeakViewerSnapshot;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface MongoPeakViewerSnapshotRepository
+    extends MongoRepository<PeakViewerSnapshot, String> {}

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/mongo/MongoViewerSessionRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/mongo/MongoViewerSessionRepository.java
@@ -1,0 +1,6 @@
+package org.giglab.live.infrastructure.mongo;
+
+import org.giglab.live.domain.model.ViewerSession;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface MongoViewerSessionRepository extends MongoRepository<ViewerSession, String> {}

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/ViewerRedisRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/ViewerRedisRepository.java
@@ -1,0 +1,123 @@
+package org.giglab.live.infrastructure.redis;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.SessionCallback;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ViewerRedisRepository {
+
+  private static final String VIEWERS_KEY = "LIVE:ROOM:%s:VIEWERS";
+  private static final String SESSION_KEY = "LIVE:VIEWER:%s";
+  private static final String FIELD_JOIN_AT = "joinAt";
+  private static final String FIELD_ROOM_ID = "roomId";
+  private static final String FIELD_USER_ID = "userId";
+  private static final Duration VIEWER_TTL = Duration.ofHours(12);
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  public void addViewer(String roomId, String sessionId) {
+    String sessionKey = sessionKey(sessionId);
+    Map<String, String> fields =
+        Map.of(FIELD_JOIN_AT, String.valueOf(Instant.now().toEpochMilli()), FIELD_ROOM_ID, roomId);
+
+    redisTemplate.execute(
+        new SessionCallback<List<Object>>() {
+          @Override
+          @SuppressWarnings("unchecked")
+          public <K, V> List<Object> execute(RedisOperations<K, V> ops) throws DataAccessException {
+            ops.multi();
+            ops.opsForHash().putAll((K) sessionKey, fields);
+            ops.expire((K) sessionKey, VIEWER_TTL);
+            ops.opsForSet().add((K) viewersKey(roomId), (V) sessionId);
+            return ops.exec();
+          }
+        });
+  }
+
+  public void saveUserId(String sessionId, String userId) {
+    redisTemplate.opsForHash().put(sessionKey(sessionId), FIELD_USER_ID, userId);
+  }
+
+  public Optional<ViewerContext> getAndRemoveViewer(String sessionId) {
+    Map<Object, Object> entries = redisTemplate.opsForHash().entries(sessionKey(sessionId));
+
+    String roomId = (String) entries.get(FIELD_ROOM_ID);
+    String joinAtStr = (String) entries.get(FIELD_JOIN_AT);
+
+    if (roomId == null || joinAtStr == null) {
+      return Optional.empty();
+    }
+
+    final String userId = (String) entries.get(FIELD_USER_ID);
+    final Instant joinAt = Instant.ofEpochMilli(Long.parseLong(joinAtStr));
+
+    String sessionHashKey = sessionKey(sessionId);
+    String viewersSetKey = viewersKey(roomId);
+    redisTemplate.execute(
+        new SessionCallback<List<Object>>() {
+          @Override
+          @SuppressWarnings("unchecked")
+          public <K, V> List<Object> execute(RedisOperations<K, V> ops) throws DataAccessException {
+            ops.multi();
+            ops.opsForSet().remove((K) viewersSetKey, (V) sessionId);
+            ops.delete((K) sessionHashKey);
+            return ops.exec();
+          }
+        });
+
+    return Optional.of(new ViewerContext(sessionId, roomId, userId, joinAt));
+  }
+
+  public long getViewerCount(String roomId) {
+    Long count = redisTemplate.opsForSet().size(viewersKey(roomId));
+    return count != null ? count : 0L;
+  }
+
+  public Set<String> getActiveRoomIds() {
+    ScanOptions options = ScanOptions.scanOptions().match("LIVE:ROOM:*:VIEWERS").count(100).build();
+
+    Set<String> roomIds = new HashSet<>();
+    redisTemplate.execute(
+        (RedisCallback<Void>)
+            connection -> {
+              try (Cursor<byte[]> cursor = connection.keyCommands().scan(options)) {
+                while (cursor.hasNext()) {
+                  String key = new String(cursor.next());
+                  // "LIVE:ROOM:{roomId}:VIEWERS" → roomId
+                  roomIds.add(key.split(":")[2]);
+                }
+              } catch (Exception e) {
+                log.error("활성 방 목록 SCAN 실패: {}", e.getMessage(), e);
+              }
+              return null;
+            });
+    return roomIds;
+  }
+
+  private String viewersKey(String roomId) {
+    return String.format(VIEWERS_KEY, roomId);
+  }
+
+  private String sessionKey(String sessionId) {
+    return String.format(SESSION_KEY, sessionId);
+  }
+
+  public record ViewerContext(String sessionId, String roomId, String userId, Instant joinAt) {}
+}

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/ViewerRedisRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/ViewerRedisRepository.java
@@ -46,13 +46,21 @@ public class ViewerRedisRepository {
             ops.opsForHash().putAll((K) sessionKey, fields);
             ops.expire((K) sessionKey, VIEWER_TTL);
             ops.opsForSet().add((K) viewersKey(roomId), (V) sessionId);
+            ops.expire((K) viewersKey(roomId), VIEWER_TTL);
             return ops.exec();
           }
         });
   }
 
   public void saveUserId(String sessionId, String userId) {
-    redisTemplate.opsForHash().put(sessionKey(sessionId), FIELD_USER_ID, userId);
+    String key = sessionKey(sessionId);
+    Boolean exists = redisTemplate.hasKey(key);
+    if (!Boolean.TRUE.equals(exists)) {
+      log.warn("saveUserId 스킵 - 세션 Hash 없음: sessionId={}", sessionId);
+      return;
+    }
+    redisTemplate.opsForHash().put(key, FIELD_USER_ID, userId);
+    redisTemplate.expire(key, VIEWER_TTL);
   }
 
   public Optional<ViewerContext> getAndRemoveViewer(String sessionId) {
@@ -81,6 +89,12 @@ public class ViewerRedisRepository {
             return ops.exec();
           }
         });
+
+    Long remaining = redisTemplate.opsForSet().size(viewersSetKey);
+    if (remaining != null && remaining == 0) {
+      redisTemplate.delete(viewersSetKey);
+      log.debug("빈 VIEWERS Set 삭제 - roomId={}", roomId);
+    }
 
     return Optional.of(new ViewerContext(sessionId, roomId, userId, joinAt));
   }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/ViewerRedisRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/ViewerRedisRepository.java
@@ -1,5 +1,6 @@
 package org.giglab.live.infrastructure.redis;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashSet;
@@ -38,13 +39,19 @@ public class ViewerRedisRepository {
         Map.of(FIELD_JOIN_AT, String.valueOf(Instant.now().toEpochMilli()), FIELD_ROOM_ID, roomId);
 
     redisTemplate.execute(
+        // 하나의 커넥션에서 명령을 수행
         new SessionCallback<List<Object>>() {
           @Override
           @SuppressWarnings("unchecked")
           public <K, V> List<Object> execute(RedisOperations<K, V> ops) throws DataAccessException {
             ops.multi();
+            // session Hash 저장
+            // session id 별 joinAt, roomId, userId 정보 저장 (userId는 CHAT_JOIN 시점에 업데이트)
+            // LEAVE 시점에 joinAt과 roomId 조회해서 시청기록과 roomId 저장
             ops.opsForHash().putAll((K) sessionKey, fields);
             ops.expire((K) sessionKey, VIEWER_TTL);
+            // viewer key 에서 sessionId 추가
+            // SCARD 한 번으로 동시 시청자 수 조회하도록 사용
             ops.opsForSet().add((K) viewersKey(roomId), (V) sessionId);
             ops.expire((K) viewersKey(roomId), VIEWER_TTL);
             return ops.exec();
@@ -113,9 +120,14 @@ public class ViewerRedisRepository {
             connection -> {
               try (Cursor<byte[]> cursor = connection.keyCommands().scan(options)) {
                 while (cursor.hasNext()) {
-                  String key = new String(cursor.next());
+                  String key = new String(cursor.next(), StandardCharsets.UTF_8);
                   // "LIVE:ROOM:{roomId}:VIEWERS" → roomId
-                  roomIds.add(key.split(":")[2]);
+                  String[] parts = key.split(":");
+                  if (parts.length >= 3) {
+                    roomIds.add(parts[2]);
+                  } else {
+                    log.warn("예상치 못한 Redis 키 포맷 - key={}", key);
+                  }
                 }
               } catch (Exception e) {
                 log.error("활성 방 목록 SCAN 실패: {}", e.getMessage(), e);

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionController.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionController.java
@@ -7,8 +7,10 @@ import org.giglab.live.application.command.ActionDispatcher;
 import org.giglab.live.application.dto.action.ActionRequest;
 import org.giglab.live.application.dto.action.ActionResponse;
 import org.giglab.live.application.service.ChatMessageService;
+import org.giglab.live.application.service.ViewerSessionService;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Controller;
 
@@ -22,12 +24,14 @@ public class RoomActionController {
   private final ActionDispatcher dispatcher;
   private final SimpMessageSendingOperations operations;
   private final ChatMessageService chatMessageService;
+  private final ViewerSessionService viewerSessionService;
 
   @MessageMapping(DESTINATION)
-  public void handle(@Valid ActionRequest req) {
+  public void handle(@Valid ActionRequest req, SimpMessageHeaderAccessor headerAccessor) {
     ActionResponse res = dispatcher.dispatch(req);
     operations.convertAndSend(SUBSCRIBE_PREFIX + req.roomId(), res);
     chatMessageService.saveIfNeeded(res);
+    viewerSessionService.saveUserIdIfJoin(req, headerAccessor.getSessionId());
   }
 
   @MessageExceptionHandler

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionController.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionController.java
@@ -31,7 +31,11 @@ public class RoomActionController {
     ActionResponse res = dispatcher.dispatch(req);
     operations.convertAndSend(SUBSCRIBE_PREFIX + req.roomId(), res);
     chatMessageService.saveIfNeeded(res);
-    viewerSessionService.saveUserIdIfJoin(req, headerAccessor.getSessionId());
+    try {
+      viewerSessionService.saveUserIdIfJoin(req, headerAccessor.getSessionId());
+    } catch (Exception e) {
+      log.warn("시청자 userId 저장 실패 (무시) - sessionId={}", headerAccessor.getSessionId(), e);
+    }
   }
 
   @MessageExceptionHandler

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/event/StompSessionEventListener.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/event/StompSessionEventListener.java
@@ -2,11 +2,13 @@ package org.giglab.live.presentation.event;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.giglab.live.domain.model.ViewerSession;
 import org.giglab.live.infrastructure.mongo.MongoViewerSessionRepository;
 import org.giglab.live.infrastructure.redis.ViewerRedisRepository;
+import org.giglab.live.infrastructure.redis.ViewerRedisRepository.ViewerContext;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
@@ -43,30 +45,32 @@ public class StompSessionEventListener {
   public void onDisconnect(SessionDisconnectEvent event) {
     String sessionId = event.getSessionId();
 
-    viewerRedisRepository
-        .getAndRemoveViewer(sessionId)
-        .ifPresent(
-            ctx -> {
-              Instant leaveAt = Instant.now();
-              long durationSeconds = Duration.between(ctx.joinAt(), leaveAt).getSeconds();
+    Optional<ViewerContext> findViewer = viewerRedisRepository.getAndRemoveViewer(sessionId);
+    if (findViewer.isEmpty()) {
+      log.debug("세션 정보 없음 - sessionId={}", sessionId);
+      return;
+    }
 
-              ViewerSession session =
-                  ViewerSession.builder()
-                      .sessionId(ctx.sessionId())
-                      .roomId(ctx.roomId())
-                      .userId(ctx.userId())
-                      .joinAt(ctx.joinAt())
-                      .leaveAt(leaveAt)
-                      .durationSeconds(durationSeconds)
-                      .build();
+    ViewerContext ctx = findViewer.get();
+    Instant leaveAt = Instant.now();
+    long durationSeconds = Duration.between(ctx.joinAt(), leaveAt).getSeconds();
 
-              viewerSessionRepository.save(session);
-              log.debug(
-                  "시청자 퇴장 저장 - sessionId={}, roomId={}, duration={}s",
-                  sessionId,
-                  ctx.roomId(),
-                  durationSeconds);
-            });
+    ViewerSession session =
+        ViewerSession.builder()
+            .sessionId(ctx.sessionId())
+            .roomId(ctx.roomId())
+            .userId(ctx.userId())
+            .joinAt(ctx.joinAt())
+            .leaveAt(leaveAt)
+            .durationSeconds(durationSeconds)
+            .build();
+
+    viewerSessionRepository.save(session);
+    log.debug(
+        "시청자 퇴장 저장 - sessionId={}, roomId={}, duration={}s",
+        sessionId,
+        ctx.roomId(),
+        durationSeconds);
   }
 
   // /sub/room/{roomId} 만 처리, /sub/room/{roomId}/host 등 하위 경로 제외

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/event/StompSessionEventListener.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/event/StompSessionEventListener.java
@@ -55,6 +55,7 @@ public class StompSessionEventListener {
     Instant leaveAt = Instant.now();
     long durationSeconds = Duration.between(ctx.joinAt(), leaveAt).getSeconds();
 
+    // 시청 기록 저장
     ViewerSession session =
         ViewerSession.builder()
             .sessionId(ctx.sessionId())

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/event/StompSessionEventListener.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/event/StompSessionEventListener.java
@@ -35,6 +35,10 @@ public class StompSessionEventListener {
     }
 
     String sessionId = accessor.getSessionId();
+    if (sessionId == null) {
+      log.warn("sessionId 없음 - 입장 처리 스킵: destination={}", destination);
+      return;
+    }
     String roomId = extractRoomId(destination);
 
     viewerRedisRepository.addViewer(roomId, sessionId);
@@ -53,7 +57,7 @@ public class StompSessionEventListener {
 
     ViewerContext ctx = findViewer.get();
     Instant leaveAt = Instant.now();
-    long durationSeconds = Duration.between(ctx.joinAt(), leaveAt).getSeconds();
+    long durationSeconds = Math.max(0, Duration.between(ctx.joinAt(), leaveAt).getSeconds());
 
     // 시청 기록 저장
     ViewerSession session =

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/event/StompSessionEventListener.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/event/StompSessionEventListener.java
@@ -1,0 +1,84 @@
+package org.giglab.live.presentation.event;
+
+import java.time.Duration;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.giglab.live.domain.model.ViewerSession;
+import org.giglab.live.infrastructure.mongo.MongoViewerSessionRepository;
+import org.giglab.live.infrastructure.redis.ViewerRedisRepository;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompSessionEventListener {
+
+  private static final String ROOM_DESTINATION_PREFIX = "/sub/room/";
+
+  private final ViewerRedisRepository viewerRedisRepository;
+  private final MongoViewerSessionRepository viewerSessionRepository;
+
+  @EventListener
+  public void onSubscribe(SessionSubscribeEvent event) {
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+    String destination = accessor.getDestination();
+
+    if (destination == null || !isRoomDestination(destination)) {
+      return;
+    }
+
+    String sessionId = accessor.getSessionId();
+    String roomId = extractRoomId(destination);
+
+    viewerRedisRepository.addViewer(roomId, sessionId);
+    log.debug("시청자 입장 - sessionId={}, roomId={}", sessionId, roomId);
+  }
+
+  @EventListener
+  public void onDisconnect(SessionDisconnectEvent event) {
+    String sessionId = event.getSessionId();
+
+    viewerRedisRepository
+        .getAndRemoveViewer(sessionId)
+        .ifPresent(
+            ctx -> {
+              Instant leaveAt = Instant.now();
+              long durationSeconds = Duration.between(ctx.joinAt(), leaveAt).getSeconds();
+
+              ViewerSession session =
+                  ViewerSession.builder()
+                      .sessionId(ctx.sessionId())
+                      .roomId(ctx.roomId())
+                      .userId(ctx.userId())
+                      .joinAt(ctx.joinAt())
+                      .leaveAt(leaveAt)
+                      .durationSeconds(durationSeconds)
+                      .build();
+
+              viewerSessionRepository.save(session);
+              log.debug(
+                  "시청자 퇴장 저장 - sessionId={}, roomId={}, duration={}s",
+                  sessionId,
+                  ctx.roomId(),
+                  durationSeconds);
+            });
+  }
+
+  // /sub/room/{roomId} 만 처리, /sub/room/{roomId}/host 등 하위 경로 제외
+  private boolean isRoomDestination(String destination) {
+    if (!destination.startsWith(ROOM_DESTINATION_PREFIX)) {
+      return false;
+    }
+    String path = destination.substring(ROOM_DESTINATION_PREFIX.length());
+    return !path.isEmpty() && !path.contains("/");
+  }
+
+  private String extractRoomId(String destination) {
+    return destination.substring(ROOM_DESTINATION_PREFIX.length());
+  }
+}

--- a/live-chat-server/src/main/resources/application-dev.yml
+++ b/live-chat-server/src/main/resources/application-dev.yml
@@ -18,3 +18,6 @@ spring:
 
 cors:
   allowed-origins: https://your-domain.com
+
+scheduling:
+  enabled: true

--- a/live-chat-server/src/main/resources/application-local.yml
+++ b/live-chat-server/src/main/resources/application-local.yml
@@ -38,3 +38,6 @@ async:
     core-pool-size: 1
     max-pool-size: 2
     queue-capacity: 100
+
+scheduling:
+  enabled: true

--- a/live-chat-server/src/test/java/org/giglab/live/application/service/FaqAnswerServiceTest.java
+++ b/live-chat-server/src/test/java/org/giglab/live/application/service/FaqAnswerServiceTest.java
@@ -28,6 +28,7 @@ class FaqAnswerServiceTest {
 
   @Mock private FaqAnswerPort faqAnswerPort;
   @Mock private SimpMessagingTemplate operations;
+  @Mock private ChatMessageService chatMessageService;
 
   @InjectMocks private FaqAnswerService service;
 

--- a/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionControllerTest.java
+++ b/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionControllerTest.java
@@ -14,11 +14,14 @@ import org.giglab.live.application.dto.action.ActionRequest;
 import org.giglab.live.application.dto.action.ActionResponse;
 import org.giglab.live.application.dto.action.Actor;
 import org.giglab.live.application.service.ChatMessageService;
+import org.giglab.live.application.service.ViewerSessionService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,11 +33,17 @@ class RoomActionControllerTest {
 
   @Mock private ChatMessageService chatMessageService;
 
+  @Mock private ViewerSessionService viewerSessionService;
+
   private RoomActionController controller;
+  private SimpMessageHeaderAccessor headerAccessor;
 
   @BeforeEach
   void setUp() {
-    controller = new RoomActionController(dispatcher, messaging, chatMessageService);
+    controller =
+        new RoomActionController(dispatcher, messaging, chatMessageService, viewerSessionService);
+    headerAccessor = Mockito.mock(SimpMessageHeaderAccessor.class);
+    Mockito.lenient().when(headerAccessor.getSessionId()).thenReturn("test-session-id");
   }
 
   @Test
@@ -46,7 +55,7 @@ class RoomActionControllerTest {
     when(dispatcher.dispatch(request)).thenReturn(response);
 
     // When
-    controller.handle(request);
+    controller.handle(request, headerAccessor);
 
     // Then
     verify(dispatcher).dispatch(request);
@@ -63,7 +72,7 @@ class RoomActionControllerTest {
     when(dispatcher.dispatch(request)).thenReturn(response);
 
     // When
-    controller.handle(request);
+    controller.handle(request, headerAccessor);
 
     // Then
     verify(messaging).convertAndSend(eq("/sub/room/" + roomId), any(ActionResponse.class));
@@ -80,7 +89,7 @@ class RoomActionControllerTest {
     // When & Then
     // 단위 테스트에서 직접 handle() 호출 시 예외가 전파됨
     // 실제 Spring STOMP 인프라에서는 @MessageExceptionHandler 가 이를 가로채 세션을 유지함
-    assertThrows(IllegalArgumentException.class, () -> controller.handle(request));
+    assertThrows(IllegalArgumentException.class, () -> controller.handle(request, headerAccessor));
     verify(messaging, never()).convertAndSend(anyString(), any(ActionResponse.class));
   }
 
@@ -107,7 +116,7 @@ class RoomActionControllerTest {
     when(dispatcher.dispatch(request)).thenReturn(response);
 
     // When
-    controller.handle(request);
+    controller.handle(request, headerAccessor);
 
     // Then
     verify(messaging).convertAndSend(eq("/sub/room/ROOM_1"), any(ActionResponse.class));
@@ -122,7 +131,7 @@ class RoomActionControllerTest {
     when(dispatcher.dispatch(request)).thenReturn(response);
 
     // When
-    controller.handle(request);
+    controller.handle(request, headerAccessor);
 
     // Then
     verify(messaging).convertAndSend(eq("/sub/room/ROOM_1"), any(ActionResponse.class));
@@ -137,7 +146,7 @@ class RoomActionControllerTest {
     when(dispatcher.dispatch(request)).thenReturn(response);
 
     // When
-    controller.handle(request);
+    controller.handle(request, headerAccessor);
 
     // Then
     verify(messaging).convertAndSend(eq("/sub/room/ROOM_1"), any(ActionResponse.class));


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
실시간 방송 중 시청자 세션을 Redis에 추적하고, 주기적으로 피크 시청자 수 스냅샷을 MongoDB에 저장하는 기능을 구현합니다. STOMP 세션 이벤트를 감지하여 시청자 입장/퇴장을 자동으로 처리합니다.


### Issue
- closes #63


### Why
- 실시간 방송에서 현재 접속 중인 시청자 수를 빠르게 조회하기 위해 Redis를 활용한 세션 관리가 필요합니다.
- 방송별 피크 시청자 수를 기록해 통계/분석 용도로 활용하기 위해 MongoDB에 스냅샷 저장이 필요합니다.
- STOMP 세션 단절(비정상 종료 포함) 시에도 시청자 정보가 정리될 수 있도록 이벤트 리스너 기반 처리가 필요합니다.


### What
- `ViewerSession` 도메인 모델 및 `ViewerRedisRepository` 구현 — 시청자 세션 정보를 Redis에 저장/조회/삭제
- `PeakViewerSnapshot` 도메인 모델 및 `MongoPeakViewerSnapshotRepository` 구현 — 피크 시청자 수 스냅샷 MongoDB 저장
- `ViewerSnapshotScheduler` 구현 — 주기적으로 현재 시청자 수를 집계해 피크 스냅샷 기록
- `StompSessionEventListener` 구현 — STOMP 세션 연결/해제 이벤트를 감지해 시청자 세션 자동 처리
- `SchedulingConfig` 분리 — 스케줄러 설정을 별도 파일로 추출
- `ViewerSessionService` early return 패턴 적용 — 가독성 개선


### How
- Redis Hash 구조로 방송 세션별 시청자 목록을 관리하며, TTL을 설정해 방송 종료 후 자동 만료
- `ApplicationListener<SessionDisconnectEvent>`를 구현하여 WebSocket 비정상 종료 시에도 시청자 세션이 정리되도록 처리
- 스케줄러는 `@Scheduled`로 주기적으로 실행되며, 현재 Redis의 시청자 수와 기존 피크 값을 비교해 업데이트
- `SchedulingConfig`를 `@EnableScheduling`이 있는 별도 설정 클래스로 분리해 테스트 시 선택적 활성화 가능


### Test
- `RoomActionControllerTest` — 시청자 입장/퇴장 API 연동 테스트 케이스 수정 및 추가
- `FaqAnswerServiceTest` — 기존 테스트 import 정리
- 로컬 환경에서 Redis 및 MongoDB 연동 후 방송 입장/퇴장 시 세션 저장·삭제 및 스냅샷 기록 확인