### PR TITLE
[#70] feat: 라이브 방송 채팅 시뮬레이션 메시지 생성 기능 구현

### DIFF
--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/client/RestCommerceClient.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/client/RestCommerceClient.java
@@ -1,10 +1,12 @@
 package org.giglab.live.infrastructure.client;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.giglab.live.application.port.external.FaqAnswerPort;
+import org.giglab.live.simulation.SimulationMessages;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.RequestEntity;
@@ -52,5 +54,34 @@ public class RestCommerceClient implements FaqAnswerPort {
     }
 
     return (String) answer;
+  }
+
+  public SimulationMessages getSimulationMessages(Long productId) {
+    String url =
+        commerceCoreUrl + commerceCoreBasePath + "/products/" + productId + "/simulation-messages";
+    var res =
+        restTemplate.exchange(
+            RequestEntity.get(URI.create(url)).build(),
+            new ParameterizedTypeReference<Map<String, Object>>() {});
+
+    Map<String, Object> body = res.getBody();
+    if (body == null) {
+      return null;
+    }
+
+    Object dataField = body.get("data");
+    if (!(dataField instanceof Map)) {
+      return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> data = (Map<String, Object>) dataField;
+
+    @SuppressWarnings("unchecked")
+    List<String> chatMessages = (List<String>) data.getOrDefault("chatMessages", List.of());
+    @SuppressWarnings("unchecked")
+    List<String> faqQuestions = (List<String>) data.getOrDefault("faqQuestions", List.of());
+
+    return new SimulationMessages(chatMessages, faqQuestions);
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/simulation/SimulationController.java
+++ b/live-chat-server/src/main/java/org/giglab/live/simulation/SimulationController.java
@@ -1,0 +1,29 @@
+package org.giglab.live.simulation;
+
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.presentation.api.response.ApiResponse;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/simulation")
+@Profile("local")
+@RequiredArgsConstructor
+public class SimulationController {
+
+  private final SimulationService simulationService;
+
+  @PostMapping("/run")
+  public ResponseEntity<ApiResponse<String>> run(@RequestBody SimulationRequest request) {
+    simulationService.run(
+        request.roomId(),
+        request.productId(),
+        request.viewerCount() > 0 ? request.viewerCount() : 8,
+        request.messageCount() > 0 ? request.messageCount() : 20);
+    return ResponseEntity.ok(ApiResponse.success("시뮬레이션 시작됨"));
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/simulation/SimulationMessages.java
+++ b/live-chat-server/src/main/java/org/giglab/live/simulation/SimulationMessages.java
@@ -1,0 +1,10 @@
+package org.giglab.live.simulation;
+
+import java.util.List;
+
+public record SimulationMessages(List<String> chatMessages, List<String> faqQuestions) {
+
+  public boolean isEmpty() {
+    return chatMessages.isEmpty() && faqQuestions.isEmpty();
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/simulation/SimulationRequest.java
+++ b/live-chat-server/src/main/java/org/giglab/live/simulation/SimulationRequest.java
@@ -1,0 +1,3 @@
+package org.giglab.live.simulation;
+
+public record SimulationRequest(String roomId, Long productId, int viewerCount, int messageCount) {}

--- a/live-chat-server/src/main/java/org/giglab/live/simulation/SimulationScenario.java
+++ b/live-chat-server/src/main/java/org/giglab/live/simulation/SimulationScenario.java
@@ -1,0 +1,54 @@
+package org.giglab.live.simulation;
+
+import java.util.List;
+import org.giglab.live.application.dto.action.Actor;
+
+public class SimulationScenario {
+
+  public static final List<Actor> VIEWERS =
+      List.of(
+          new Actor("sim_user_01", "viewer01@test.com", "민지"),
+          new Actor("sim_user_02", "viewer02@test.com", "현우"),
+          new Actor("sim_user_03", "viewer03@test.com", "소연"),
+          new Actor("sim_user_04", "viewer04@test.com", "태양"),
+          new Actor("sim_user_05", "viewer05@test.com", "하은"),
+          new Actor("sim_user_06", "viewer06@test.com", "준서"),
+          new Actor("sim_user_07", "viewer07@test.com", "나연"),
+          new Actor("sim_user_08", "viewer08@test.com", "도현"),
+          new Actor("sim_user_09", "viewer09@test.com", "서아"),
+          new Actor("sim_user_10", "viewer10@test.com", "지훈"));
+
+  // 저장된 시뮬레이션 메시지가 없을 때 사용하는 폴백 데이터
+  public static final List<String> FALLBACK_CHAT_MESSAGES =
+      List.of(
+          "이거 진짜 효과 있나요?",
+          "가격이 어떻게 돼요?",
+          "피부 트러블 있어도 써도 되나요?",
+          "배송 얼마나 걸려요?",
+          "저도 써봤는데 진짜 좋더라구요!",
+          "할인 언제까지예요?",
+          "민감성 피부인데 괜찮을까요?",
+          "향이 강한가요?",
+          "유통기한이 어떻게 돼요?",
+          "이거 진짜 사야겠다!",
+          "냉장 보관해야 하나요?",
+          "다른 제품이랑 같이 써도 되나요?",
+          "재구매 했어요 진짜 최고",
+          "선물 포장 가능한가요?",
+          "임산부도 사용 가능한가요?",
+          "해외배송도 되나요?",
+          "몇 번이나 사용할 수 있어요?",
+          "후기 믿을 수 있나요?",
+          "색깔이 실제로도 저렇게 예쁜가요?",
+          "지금 재고 있나요?");
+
+  public static final List<String> FALLBACK_FAQ_QUESTIONS =
+      List.of(
+          "이 제품의 주요 성분이 무엇인가요?",
+          "민감성 피부에도 사용 가능한가요?",
+          "하루에 몇 번 사용하는 것이 좋나요?",
+          "유통기한이 어떻게 되나요?",
+          "다른 스킨케어 제품과 함께 사용해도 되나요?");
+
+  private SimulationScenario() {}
+}

--- a/live-chat-server/src/main/java/org/giglab/live/simulation/SimulationService.java
+++ b/live-chat-server/src/main/java/org/giglab/live/simulation/SimulationService.java
@@ -1,0 +1,132 @@
+package org.giglab.live.simulation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.giglab.live.application.command.ActionType;
+import org.giglab.live.application.dto.action.ActionRequest;
+import org.giglab.live.application.dto.action.ActionResponse;
+import org.giglab.live.application.dto.action.Actor;
+import org.giglab.live.application.service.ChatMessageService;
+import org.giglab.live.application.service.FaqAnswerService;
+import org.giglab.live.infrastructure.client.RestCommerceClient;
+import org.springframework.context.annotation.Profile;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@Profile("local")
+@RequiredArgsConstructor
+public class SimulationService {
+
+  private static final String SUB_PREFIX = "/sub/room/";
+
+  private final SimpMessagingTemplate operations;
+  private final ChatMessageService chatMessageService;
+  private final FaqAnswerService faqAnswerService;
+  private final RestCommerceClient commerceClient;
+
+  @Async("faqAsyncExecutor")
+  public void run(String roomId, Long productId, int viewerCount, int messageCount) {
+    log.info("[Simulation] 시작 - roomId={}, productId={}", roomId, productId);
+
+    List<String> chatMessages;
+    List<String> faqQuestions;
+    try {
+      SimulationMessages simMsgs = commerceClient.getSimulationMessages(productId);
+      if (simMsgs != null && !simMsgs.isEmpty()) {
+        chatMessages = simMsgs.chatMessages();
+        faqQuestions = simMsgs.faqQuestions();
+        log.info(
+            "[Simulation] 저장된 메시지 사용 - chats={}, faqs={}",
+            chatMessages.size(),
+            faqQuestions.size());
+      } else {
+        chatMessages = SimulationScenario.FALLBACK_CHAT_MESSAGES;
+        faqQuestions = SimulationScenario.FALLBACK_FAQ_QUESTIONS;
+        log.info("[Simulation] 폴백 메시지 사용");
+      }
+    } catch (Exception e) {
+      log.warn("[Simulation] 메시지 조회 실패, 폴백 사용: {}", e.getMessage());
+      chatMessages = SimulationScenario.FALLBACK_CHAT_MESSAGES;
+      faqQuestions = SimulationScenario.FALLBACK_FAQ_QUESTIONS;
+    }
+
+    List<Actor> viewers =
+        SimulationScenario.VIEWERS.subList(
+            0, Math.min(viewerCount, SimulationScenario.VIEWERS.size()));
+
+    try {
+      // Phase 1: 시청자 순차 입장
+      for (Actor actor : viewers) {
+        broadcast(roomId, ActionType.CHAT_JOIN.getKey(), actor, Map.of());
+        sleep(500, 1500);
+      }
+
+      // Phase 2: 채팅 + FAQ 혼합 (4번 채팅마다 FAQ 1회 삽입)
+      int faqIdx = 0;
+      for (int i = 0; i < messageCount; i++) {
+        Actor actor = viewers.get(i % viewers.size());
+        String msg = chatMessages.get(i % chatMessages.size());
+
+        if (i > 0 && i % 4 == 0 && faqIdx < faqQuestions.size()) {
+          sendFaq(roomId, productId, actor, faqQuestions.get(faqIdx++));
+          sleep(1000, 2000);
+        }
+
+        broadcast(roomId, ActionType.CHAT_MESSAGE.getKey(), actor, Map.of("message", msg));
+        sleep(800, 2000);
+      }
+
+      // 남은 FAQ 질문 모두 발송
+      while (faqIdx < faqQuestions.size()) {
+        sendFaq(
+            roomId, productId, viewers.get(faqIdx % viewers.size()), faqQuestions.get(faqIdx++));
+        sleep(2000, 4000);
+      }
+
+      // Phase 3: 시청자 순차 퇴장
+      for (Actor actor : viewers) {
+        broadcast(roomId, ActionType.CHAT_LEAVE.getKey(), actor, Map.of());
+        sleep(1000, 2000);
+      }
+
+      log.info("[Simulation] 완료 - roomId={}", roomId);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      log.warn("[Simulation] 중단 - roomId={}", roomId);
+    }
+  }
+
+  private void sendFaq(String roomId, Long productId, Actor actor, String question) {
+    ActionRequest req =
+        new ActionRequest(
+            roomId,
+            ActionType.FAQ_QUESTION.getKey(),
+            actor,
+            Map.of("question", question, "productId", productId));
+    ActionResponse res =
+        ActionResponse.of(
+            roomId,
+            ActionType.FAQ_QUESTION.getKey(),
+            actor,
+            Map.of("question", question, "productId", productId));
+    operations.convertAndSend(SUB_PREFIX + roomId, res);
+    chatMessageService.saveIfNeeded(res);
+    faqAnswerService.generateAndBroadcast(req);
+  }
+
+  private void broadcast(String roomId, String action, Actor actor, Map<String, Object> payload) {
+    ActionResponse res = ActionResponse.of(roomId, action, actor, payload);
+    operations.convertAndSend(SUB_PREFIX + roomId, res);
+    chatMessageService.saveIfNeeded(res);
+  }
+
+  private void sleep(int min, int max) throws InterruptedException {
+    Thread.sleep(ThreadLocalRandom.current().nextInt(min, max));
+  }
+}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/controller/product/ProductController.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/controller/product/ProductController.java
@@ -18,6 +18,7 @@ import org.giglab.live.commerce.api.dto.product.GetProductLinkedCampaignsRespons
 import org.giglab.live.commerce.api.dto.product.GetProductListRequest;
 import org.giglab.live.commerce.api.dto.product.GetProductListResponse;
 import org.giglab.live.commerce.api.dto.product.GetProductResponse;
+import org.giglab.live.commerce.api.dto.product.GetSimulationMessagesResponse;
 import org.giglab.live.commerce.api.dto.product.ParsedProductResponse;
 import org.giglab.live.commerce.api.facade.ProductFacade;
 import org.giglab.live.commerce.api.response.ApiResponse;
@@ -134,6 +135,24 @@ public class ProductController {
   public ResponseEntity<ApiResponse<EmbedDocumentResponse>> embedDocument(
       @PathVariable Long documentId) {
     EmbedDocumentResponse response = productFacade.embedDocument(documentId);
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+  @Operation(
+      summary = "시뮬레이션 메시지 생성",
+      description = "임베딩된 문서 기반으로 시뮬레이션용 채팅·FAQ 메시지를 LLM으로 생성하고 저장합니다.")
+  @PostMapping("/{id}/simulation-messages")
+  public ResponseEntity<ApiResponse<GetSimulationMessagesResponse>> generateSimulationMessages(
+      @PathVariable Long id) {
+    GetSimulationMessagesResponse response = productFacade.generateSimulationMessages(id);
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+  @Operation(summary = "시뮬레이션 메시지 조회", description = "저장된 시뮬레이션용 채팅·FAQ 메시지를 조회합니다.")
+  @GetMapping("/{id}/simulation-messages")
+  public ResponseEntity<ApiResponse<GetSimulationMessagesResponse>> getSimulationMessages(
+      @PathVariable Long id) {
+    GetSimulationMessagesResponse response = productFacade.getSimulationMessages(id);
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 }

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/product/GetSimulationMessagesResponse.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/dto/product/GetSimulationMessagesResponse.java
@@ -1,0 +1,6 @@
+package org.giglab.live.commerce.api.dto.product;
+
+import java.util.List;
+
+public record GetSimulationMessagesResponse(
+    Long productId, List<String> chatMessages, List<String> faqQuestions) {}

--- a/live-commerce-api/src/main/java/org/giglab/live/commerce/api/facade/ProductFacade.java
+++ b/live-commerce-api/src/main/java/org/giglab/live/commerce/api/facade/ProductFacade.java
@@ -17,6 +17,7 @@ import org.giglab.live.commerce.api.dto.product.GetProductLinkedCampaignsRespons
 import org.giglab.live.commerce.api.dto.product.GetProductListRequest;
 import org.giglab.live.commerce.api.dto.product.GetProductListResponse;
 import org.giglab.live.commerce.api.dto.product.GetProductResponse;
+import org.giglab.live.commerce.api.dto.product.GetSimulationMessagesResponse;
 import org.giglab.live.commerce.api.dto.product.ParsedProductResponse;
 import org.giglab.live.commerce.api.dto.product.ProductFaqSampleItem;
 import org.giglab.live.commerce.api.mapper.product.ProductMapper;
@@ -32,6 +33,7 @@ import org.giglab.live.commerce.core.product.application.dto.ai.EmbedAllDocument
 import org.giglab.live.commerce.core.product.application.dto.ai.EmbedProductInfoResult;
 import org.giglab.live.commerce.core.product.application.dto.ai.GenerateProductFaqSamplesResult;
 import org.giglab.live.commerce.core.product.application.dto.ai.GetProductFaqSamplesResult;
+import org.giglab.live.commerce.core.product.application.dto.ai.SimulationMessagesResult;
 import org.giglab.live.commerce.core.product.application.dto.pdf.EmbedDocumentResult;
 import org.giglab.live.commerce.core.product.application.dto.pdf.GetDocumentListResult;
 import org.giglab.live.commerce.core.product.application.dto.pdf.ParsedProductResult;
@@ -92,6 +94,18 @@ public class ProductFacade {
         result.items().stream()
             .map(i -> new ProductFaqSampleItem(i.id(), i.question(), i.answer()))
             .toList());
+  }
+
+  public GetSimulationMessagesResponse generateSimulationMessages(Long productId) {
+    SimulationMessagesResult result = productService.generateSimulationMessages(productId);
+    return new GetSimulationMessagesResponse(
+        productId, result.chatMessages(), result.faqQuestions());
+  }
+
+  public GetSimulationMessagesResponse getSimulationMessages(Long productId) {
+    SimulationMessagesResult result = productService.getSimulationMessages(productId);
+    return new GetSimulationMessagesResponse(
+        productId, result.chatMessages(), result.faqQuestions());
   }
 
   public EmbedProductInfoResponse embedProductInfo(Long productId) {

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/ProductService.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/ProductService.java
@@ -14,6 +14,7 @@ import org.giglab.live.commerce.core.product.application.dto.ai.EmbedAllDocument
 import org.giglab.live.commerce.core.product.application.dto.ai.EmbedProductInfoResult;
 import org.giglab.live.commerce.core.product.application.dto.ai.GenerateProductFaqSamplesResult;
 import org.giglab.live.commerce.core.product.application.dto.ai.GetProductFaqSamplesResult;
+import org.giglab.live.commerce.core.product.application.dto.ai.SimulationMessagesResult;
 import org.giglab.live.commerce.core.product.application.dto.pdf.EmbedDocumentResult;
 import org.giglab.live.commerce.core.product.application.dto.pdf.GetDocumentListResult;
 import org.giglab.live.commerce.core.product.application.dto.pdf.ParsedPdfData;
@@ -25,12 +26,15 @@ import org.giglab.live.commerce.core.product.application.usecase.GetProductUseCa
 import org.giglab.live.commerce.core.product.application.usecase.ai.AskProductQuestionUseCase;
 import org.giglab.live.commerce.core.product.application.usecase.ai.CreateProductDocumentUseCase;
 import org.giglab.live.commerce.core.product.application.usecase.ai.CreateProductFaqSamplesUseCase;
+import org.giglab.live.commerce.core.product.application.usecase.ai.CreateSimulationMessagesUseCase;
 import org.giglab.live.commerce.core.product.application.usecase.ai.EmbedAllDocumentsUseCase;
 import org.giglab.live.commerce.core.product.application.usecase.ai.EmbedDocumentUseCase;
 import org.giglab.live.commerce.core.product.application.usecase.ai.EmbedProductInfoUseCase;
 import org.giglab.live.commerce.core.product.application.usecase.ai.GenerateProductFaqSamplesUseCase;
+import org.giglab.live.commerce.core.product.application.usecase.ai.GenerateSimulationMessagesUseCase;
 import org.giglab.live.commerce.core.product.application.usecase.ai.GetDocumentListUseCase;
 import org.giglab.live.commerce.core.product.application.usecase.ai.GetProductFaqSamplesUseCase;
+import org.giglab.live.commerce.core.product.application.usecase.ai.GetSimulationMessagesUseCase;
 import org.giglab.live.commerce.core.product.application.usecase.ai.MarkAllDocumentsEmbeddedUseCase;
 import org.giglab.live.commerce.core.product.application.usecase.ai.ParseProductPdfUseCase;
 import org.springframework.stereotype.Service;
@@ -54,6 +58,9 @@ public class ProductService {
   private final EmbedProductInfoUseCase embedProductInfoUseCase;
   private final EmbedAllDocumentsUseCase embedAllDocumentsUseCase;
   private final MarkAllDocumentsEmbeddedUseCase markAllDocumentsEmbeddedUseCase;
+  private final GenerateSimulationMessagesUseCase generateSimulationMessagesUseCase;
+  private final CreateSimulationMessagesUseCase createSimulationMessagesUseCase;
+  private final GetSimulationMessagesUseCase getSimulationMessagesUseCase;
 
   public GetProductListResult getList(ProductListQuery query) {
     return getProductListUseCase.execute(query);
@@ -100,6 +107,15 @@ public class ProductService {
 
   public EmbedProductInfoResult embedProductInfo(Long productId) {
     return embedProductInfoUseCase.execute(productId);
+  }
+
+  public SimulationMessagesResult generateSimulationMessages(Long productId) {
+    SimulationMessagesResult result = generateSimulationMessagesUseCase.execute(productId);
+    return createSimulationMessagesUseCase.execute(productId, result);
+  }
+
+  public SimulationMessagesResult getSimulationMessages(Long productId) {
+    return getSimulationMessagesUseCase.execute(productId);
   }
 
   public EmbedAllDocumentsResult embedAllDocuments(Long productId) {

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/dto/ai/SimulationMessagesResult.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/dto/ai/SimulationMessagesResult.java
@@ -1,0 +1,14 @@
+package org.giglab.live.commerce.core.product.application.dto.ai;
+
+import java.util.List;
+
+public record SimulationMessagesResult(List<String> chatMessages, List<String> faqQuestions) {
+
+  public static SimulationMessagesResult empty() {
+    return new SimulationMessagesResult(List.of(), List.of());
+  }
+
+  public boolean isEmpty() {
+    return chatMessages.isEmpty() && faqQuestions.isEmpty();
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/port/persistence/ProductSimulationMessagePort.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/port/persistence/ProductSimulationMessagePort.java
@@ -1,0 +1,11 @@
+package org.giglab.live.commerce.core.product.application.port.persistence;
+
+import java.util.List;
+import org.giglab.live.commerce.core.product.domain.entity.ProductSimulationMessage;
+
+public interface ProductSimulationMessagePort {
+
+  List<ProductSimulationMessage> saveAll(List<ProductSimulationMessage> messages);
+
+  List<ProductSimulationMessage> findByProductId(Long productId);
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/usecase/ai/CreateSimulationMessagesUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/usecase/ai/CreateSimulationMessagesUseCase.java
@@ -1,0 +1,40 @@
+package org.giglab.live.commerce.core.product.application.usecase.ai;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.giglab.live.commerce.core.product.application.dto.ai.SimulationMessagesResult;
+import org.giglab.live.commerce.core.product.application.port.persistence.ProductSimulationMessagePort;
+import org.giglab.live.commerce.core.product.domain.entity.ProductSimulationMessage;
+import org.giglab.live.commerce.core.product.domain.entity.ProductSimulationMessage.MessageType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CreateSimulationMessagesUseCase {
+
+  private final ProductSimulationMessagePort productSimulationMessagePort;
+
+  @Transactional
+  public SimulationMessagesResult execute(Long productId, SimulationMessagesResult result) {
+    if (result.isEmpty()) {
+      return result;
+    }
+
+    List<ProductSimulationMessage> entities = new ArrayList<>();
+    result
+        .chatMessages()
+        .forEach(
+            msg -> entities.add(ProductSimulationMessage.create(productId, MessageType.CHAT, msg)));
+    result
+        .faqQuestions()
+        .forEach(q -> entities.add(ProductSimulationMessage.create(productId, MessageType.FAQ, q)));
+
+    productSimulationMessagePort.saveAll(entities);
+    log.info("[SimMsg] 저장 완료 - productId={}, total={}", productId, entities.size());
+    return result;
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/usecase/ai/GenerateSimulationMessagesUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/usecase/ai/GenerateSimulationMessagesUseCase.java
@@ -26,8 +26,10 @@ public class GenerateSimulationMessagesUseCase {
   private static final String SYSTEM_PROMPT =
       """
       당신은 라이브 커머스 방송 시뮬레이션 전문가입니다.
-      아래 [상품 자료]를 참고해 실제 방송에서 시청자들이 보낼 법한 채팅과 FAQ 질문을 생성하세요.
-      채팅 메시지는 짧고 자연스러운 한국어 구어체로, FAQ 질문은 상품 성분·사용법·주의사항 관련으로 작성하세요.
+      아래 [상품 자료]를 참고해 실제 방송에서 시청자들이 보낼 법한 채팅 반응과 FAQ 질문을 생성하세요.
+
+      채팅 메시지는 시청자의 즉각적인 감정 반응으로, 긍정(구매 의사, 칭찬, 기대감) / 부정(가격 부담, 의구심, 불만) / 중립(단순 질문, 정보 요청) 톤을 골고루 섞어 자연스러운 한국어 구어체로 작성하세요.
+      FAQ 질문은 상품 성분·사용법·주의사항 관련으로 작성하세요.
 
       [상품 자료]
       {context}
@@ -48,7 +50,7 @@ public class GenerateSimulationMessagesUseCase {
         ]
       }
 
-      chatMessages 20개, faqQuestions 5개를 생성하세요.
+      chatMessages 20개(긍정 8개·부정 4개·중립 8개), faqQuestions 5개를 생성하세요.
       """;
 
   private final SearchDocumentPort searchDocumentPort;

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/usecase/ai/GenerateSimulationMessagesUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/usecase/ai/GenerateSimulationMessagesUseCase.java
@@ -1,0 +1,108 @@
+package org.giglab.live.commerce.core.product.application.usecase.ai;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.giglab.live.commerce.core.product.application.dto.ai.SimulationMessagesResult;
+import org.giglab.live.commerce.core.product.application.port.ai.SearchDocumentPort;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.document.Document;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+public class GenerateSimulationMessagesUseCase {
+
+  private static final int TOP_K = 5;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private static final String SEED_QUERY = "상품 성분 사용법 주의사항 효과 부작용 보관방법";
+
+  private static final String SYSTEM_PROMPT =
+      """
+      당신은 라이브 커머스 방송 시뮬레이션 전문가입니다.
+      아래 [상품 자료]를 참고해 실제 방송에서 시청자들이 보낼 법한 채팅과 FAQ 질문을 생성하세요.
+      채팅 메시지는 짧고 자연스러운 한국어 구어체로, FAQ 질문은 상품 성분·사용법·주의사항 관련으로 작성하세요.
+
+      [상품 자료]
+      {context}
+      """;
+
+  private static final String USER_PROMPT =
+      """
+      위 상품에 대해 아래 JSON 형식으로만 반환하세요. 다른 설명 없이 JSON만 출력하세요.
+
+      {
+        "chatMessages": [
+          "채팅 메시지 1",
+          "채팅 메시지 2"
+        ],
+        "faqQuestions": [
+          "FAQ 질문 1",
+          "FAQ 질문 2"
+        ]
+      }
+
+      chatMessages 20개, faqQuestions 5개를 생성하세요.
+      """;
+
+  private final SearchDocumentPort searchDocumentPort;
+  private final ChatClient chatClient;
+
+  public GenerateSimulationMessagesUseCase(
+      SearchDocumentPort searchDocumentPort, ChatModel chatModel) {
+    this.searchDocumentPort = searchDocumentPort;
+    this.chatClient = ChatClient.create(chatModel);
+  }
+
+  public SimulationMessagesResult execute(Long productId) {
+    List<Document> docs = searchDocumentPort.search(productId, SEED_QUERY, TOP_K);
+
+    if (docs.isEmpty()) {
+      log.warn("[SimMsg] 임베딩 문서 없음 - productId={}", productId);
+      return SimulationMessagesResult.empty();
+    }
+
+    String context =
+        docs.stream().map(Document::getText).collect(Collectors.joining("\n\n---\n\n"));
+
+    String raw =
+        chatClient
+            .prompt()
+            .system(SYSTEM_PROMPT.replace("{context}", context))
+            .user(USER_PROMPT)
+            .call()
+            .content();
+
+    if (!StringUtils.hasText(raw)) {
+      return SimulationMessagesResult.empty();
+    }
+
+    try {
+      String json = raw.trim();
+      if (json.startsWith("```")) {
+        json = json.replaceAll("(?s)^```[a-z]*\\n?", "").replaceAll("```$", "").trim();
+      }
+      JsonNode node = MAPPER.readTree(json);
+      List<String> chatMessages =
+          MAPPER.convertValue(node.get("chatMessages"), new TypeReference<List<String>>() {});
+      List<String> faqQuestions =
+          MAPPER.convertValue(node.get("faqQuestions"), new TypeReference<List<String>>() {});
+
+      log.info(
+          "[SimMsg] 생성 완료 - productId={}, chats={}, faqs={}",
+          productId,
+          chatMessages.size(),
+          faqQuestions.size());
+      return new SimulationMessagesResult(chatMessages, faqQuestions);
+    } catch (Exception e) {
+      log.error("[SimMsg] 파싱 실패 - productId={}: {}", productId, e.getMessage());
+      return SimulationMessagesResult.empty();
+    }
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/usecase/ai/GetSimulationMessagesUseCase.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/application/usecase/ai/GetSimulationMessagesUseCase.java
@@ -1,0 +1,36 @@
+package org.giglab.live.commerce.core.product.application.usecase.ai;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.core.product.application.dto.ai.SimulationMessagesResult;
+import org.giglab.live.commerce.core.product.application.port.persistence.ProductSimulationMessagePort;
+import org.giglab.live.commerce.core.product.domain.entity.ProductSimulationMessage;
+import org.giglab.live.commerce.core.product.domain.entity.ProductSimulationMessage.MessageType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetSimulationMessagesUseCase {
+
+  private final ProductSimulationMessagePort productSimulationMessagePort;
+
+  public SimulationMessagesResult execute(Long productId) {
+    List<ProductSimulationMessage> all = productSimulationMessagePort.findByProductId(productId);
+
+    List<String> chatMessages =
+        all.stream()
+            .filter(m -> m.getMessageType() == MessageType.CHAT)
+            .map(ProductSimulationMessage::getContent)
+            .toList();
+
+    List<String> faqQuestions =
+        all.stream()
+            .filter(m -> m.getMessageType() == MessageType.FAQ)
+            .map(ProductSimulationMessage::getContent)
+            .toList();
+
+    return new SimulationMessagesResult(chatMessages, faqQuestions);
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/domain/entity/ProductSimulationMessage.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/domain/entity/ProductSimulationMessage.java
@@ -1,0 +1,53 @@
+package org.giglab.live.commerce.core.product.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.giglab.live.commerce.core.global.jpa.entity.AuditedEntity;
+
+@Getter
+@Builder
+@Entity
+@Table(name = "product_simulation_messages")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductSimulationMessage extends AuditedEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long productId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 10)
+  private MessageType messageType;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  public enum MessageType {
+    CHAT,
+    FAQ
+  }
+
+  public static ProductSimulationMessage create(
+      Long productId, MessageType messageType, String content) {
+    return ProductSimulationMessage.builder()
+        .productId(productId)
+        .messageType(messageType)
+        .content(content)
+        .build();
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/infrastructure/adapter/JpaProductSimulationMessageAdapter.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/infrastructure/adapter/JpaProductSimulationMessageAdapter.java
@@ -1,0 +1,25 @@
+package org.giglab.live.commerce.core.product.infrastructure.adapter;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.commerce.core.product.application.port.persistence.ProductSimulationMessagePort;
+import org.giglab.live.commerce.core.product.domain.entity.ProductSimulationMessage;
+import org.giglab.live.commerce.core.product.infrastructure.persistence.ProductSimulationMessageRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JpaProductSimulationMessageAdapter implements ProductSimulationMessagePort {
+
+  private final ProductSimulationMessageRepository repository;
+
+  @Override
+  public List<ProductSimulationMessage> saveAll(List<ProductSimulationMessage> messages) {
+    return repository.saveAll(messages);
+  }
+
+  @Override
+  public List<ProductSimulationMessage> findByProductId(Long productId) {
+    return repository.findByProductId(productId);
+  }
+}

--- a/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/infrastructure/persistence/ProductSimulationMessageRepository.java
+++ b/live-commerce-core/src/main/java/org/giglab/live/commerce/core/product/infrastructure/persistence/ProductSimulationMessageRepository.java
@@ -1,0 +1,11 @@
+package org.giglab.live.commerce.core.product.infrastructure.persistence;
+
+import java.util.List;
+import org.giglab.live.commerce.core.product.domain.entity.ProductSimulationMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductSimulationMessageRepository
+    extends JpaRepository<ProductSimulationMessage, Long> {
+
+  List<ProductSimulationMessage> findByProductId(Long productId);
+}

--- a/web-client/pages/broadcasts/[id].tsx
+++ b/web-client/pages/broadcasts/[id].tsx
@@ -133,6 +133,8 @@ function ChatQnAPanel({
   const [tab, setTab] = useState<'report' | 'chat' | 'faq'>(isEnded ? 'report' : 'chat');
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const faqBottomRef = useRef<HTMLDivElement>(null);
+  const chatContainerRef = useRef<HTMLDivElement>(null);
+  const isAtChatBottomRef = useRef(true);
   const [faqInput, setFaqInput] = useState('');
 
   const chatMessages = useMemo(
@@ -150,12 +152,19 @@ function ChatQnAPanel({
 
 
   useEffect(() => {
-    if (tab === 'chat') messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    if (tab === 'chat' && isAtChatBottomRef.current)
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, tab]);
 
   useEffect(() => {
     if (tab === 'faq') faqBottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [faqMessages, tab]);
+
+  const handleChatScroll = useCallback(() => {
+    const el = chatContainerRef.current;
+    if (!el) return;
+    isAtChatBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  }, []);
 
   const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') onSend();
@@ -259,7 +268,7 @@ function ChatQnAPanel({
           </div>
         ) : (
           <>
-            <div className="lp-messages">
+            <div className="lp-messages" ref={chatContainerRef} onScroll={handleChatScroll}>
               {chatMessages.length === 0 ? (
                 <div className="lp-empty">채팅을 시작해보세요!</div>
               ) : (

--- a/web-client/pages/broadcasts/[id].tsx
+++ b/web-client/pages/broadcasts/[id].tsx
@@ -636,6 +636,7 @@ export default function BroadcastDetail() {
   const [campaign, setCampaign] = useState<Campaign | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [simRunning, setSimRunning] = useState(false);
 
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputValue, setInputValue] = useState('');
@@ -1161,6 +1162,9 @@ export default function BroadcastDetail() {
         .btn-end { flex:1; padding:12px; background:linear-gradient(135deg,#ef4444,#dc2626); color:white; border:none; border-radius:10px; font-size:14px; font-weight:700; cursor:pointer; transition:opacity 0.2s; }
         .btn-end:hover:not(:disabled) { opacity:0.85; }
         .btn-start:disabled, .btn-end:disabled { opacity:0.5; cursor:not-allowed; }
+        .btn-sim-run { flex:1; padding:12px; background:linear-gradient(135deg,#6366f1,#4f46e5); color:white; border:none; border-radius:10px; font-size:14px; font-weight:700; cursor:pointer; transition:opacity 0.2s; }
+        .btn-sim-run:hover:not(:disabled) { opacity:0.85; }
+        .btn-sim-run:disabled { opacity:0.5; cursor:not-allowed; }
 
         .side-col { width:360px; flex-shrink:0; height:calc(100vh - 104px); position:sticky; top:80px; }
 
@@ -1233,6 +1237,31 @@ export default function BroadcastDetail() {
                   <button className="btn-end" onClick={handleEnd} disabled={actionLoading}>
                     {actionLoading ? '처리 중...' : '■ 방송 종료'}
                   </button>
+                  {process.env.NODE_ENV === 'development' && campaign.chatRoomId && (
+                    <button
+                      className="btn-sim-run"
+                      onClick={async () => {
+                        setSimRunning(true);
+                        try {
+                          await fetch(`${CHAT_API_BASE}/simulation/run`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({
+                              roomId: campaign.chatRoomId,
+                              productId: campaign.campaignProducts?.[0]?.productId ?? 1,
+                              viewerCount: 8,
+                              messageCount: 20,
+                            }),
+                          });
+                        } finally {
+                          setSimRunning(false);
+                        }
+                      }}
+                      disabled={simRunning}
+                    >
+                      {simRunning ? '시뮬레이션 실행 중...' : '🧪 시뮬레이션 실행'}
+                    </button>
+                  )}
                 </div>
               )}
 

--- a/web-client/pages/broadcasts/[id].tsx
+++ b/web-client/pages/broadcasts/[id].tsx
@@ -152,8 +152,10 @@ function ChatQnAPanel({
 
 
   useEffect(() => {
-    if (tab === 'chat' && isAtChatBottomRef.current)
-      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    if (tab === 'chat' && isAtChatBottomRef.current) {
+      const el = chatContainerRef.current;
+      if (el) el.scrollTop = el.scrollHeight;
+    }
   }, [messages, tab]);
 
   useEffect(() => {
@@ -850,6 +852,93 @@ export default function BroadcastDetail() {
     }
   };
 
+  const SIM_VIEWER_NAMES = ['하나', '두리', '세리', '네모', '다솜', '여섯', '일곱', '여덟'];
+
+  const runSimulation = async () => {
+    if (!campaign?.chatRoomId) return;
+    const roomId = campaign.chatRoomId;
+    const productId = campaign.campaignProducts?.[0]?.productId ?? 1;
+    const SockJS = (window as any).SockJS;
+    const StompJs = (window as any).StompJs;
+    if (!SockJS || !StompJs) return;
+
+    setSimRunning(true);
+    try {
+      const res = await fetch(`${API_BASE}/products/${productId}/simulation-messages`);
+      const json = await res.json();
+      const chatMessages: string[] = json?.data?.chatMessages ?? [];
+      const faqQuestions: string[] = json?.data?.faqQuestions ?? [];
+      if (chatMessages.length === 0) {
+        alert('시뮬레이션 메시지가 없습니다. 상품 상세에서 먼저 생성해주세요.');
+        return;
+      }
+
+      const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+      const rand = (min: number, max: number) => Math.floor(Math.random() * (max - min)) + min;
+      const sendAction = (client: any, action: string, actor: string, payload: object) => {
+        try {
+          client.send('/send/room.action', {}, JSON.stringify({
+            roomId, action,
+            actor: { userId: actor, username: actor, sender: actor },
+            payload,
+          }));
+        } catch { /* 무시 */ }
+      };
+
+      // Phase 1: 가상 시청자 순차 입장
+      const viewers: { name: string; client: any }[] = [];
+      for (const name of SIM_VIEWER_NAMES) {
+        await new Promise<void>((resolve) => {
+          const socket = new SockJS(`${WS_BASE_URL}/ws`);
+          const client = StompJs.Stomp.over(socket);
+          client.debug = () => {};
+          client.heartbeat.outgoing = 0;
+          client.heartbeat.incoming = 0;
+          client.connect({}, () => {
+            client.subscribe(`/sub/room/${roomId}`, () => {});
+            sendAction(client, 'CHAT.JOIN', name, {});
+            viewers.push({ name, client });
+            resolve();
+          }, () => resolve());
+        });
+        await sleep(rand(500, 1500));
+      }
+
+      // Phase 2: 채팅 + FAQ 혼합 (4채팅마다 FAQ 1회)
+      let faqIdx = 0;
+      const messageCount = Math.min(chatMessages.length, 20);
+      for (let i = 0; i < messageCount; i++) {
+        const viewer = viewers[i % viewers.length];
+        if (i > 0 && i % 4 === 0 && faqIdx < faqQuestions.length) {
+          sendAction(viewer.client, 'FAQ.QUESTION', viewer.name, {
+            question: faqQuestions[faqIdx++], productId,
+          });
+          await sleep(rand(1000, 2000));
+        }
+        sendAction(viewer.client, 'CHAT.MESSAGE', viewer.name, { message: chatMessages[i % chatMessages.length] });
+        await sleep(rand(800, 2000));
+      }
+
+      // 남은 FAQ 발송
+      while (faqIdx < faqQuestions.length) {
+        const viewer = viewers[faqIdx % viewers.length];
+        sendAction(viewer.client, 'FAQ.QUESTION', viewer.name, {
+          question: faqQuestions[faqIdx++], productId,
+        });
+        await sleep(rand(2000, 4000));
+      }
+
+      // Phase 3: 가상 시청자 순차 퇴장
+      for (const viewer of viewers) {
+        sendAction(viewer.client, 'CHAT.LEAVE', viewer.name, {});
+        await sleep(rand(300, 800));
+        try { viewer.client.disconnect(); } catch { /* 무시 */ }
+      }
+    } finally {
+      setSimRunning(false);
+    }
+  };
+
   const disconnect = () => {
     isConnectingRef.current = false;
     if (campaign?.chatRoomId) historyLoadedRoomsRef.current.delete(campaign.chatRoomId);
@@ -1249,26 +1338,10 @@ export default function BroadcastDetail() {
                   {process.env.NODE_ENV === 'development' && campaign.chatRoomId && (
                     <button
                       className="btn-sim-run"
-                      onClick={async () => {
-                        setSimRunning(true);
-                        try {
-                          await fetch(`${CHAT_API_BASE}/simulation/run`, {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({
-                              roomId: campaign.chatRoomId,
-                              productId: campaign.campaignProducts?.[0]?.productId ?? 1,
-                              viewerCount: 8,
-                              messageCount: 20,
-                            }),
-                          });
-                        } finally {
-                          setSimRunning(false);
-                        }
-                      }}
+                      onClick={runSimulation}
                       disabled={simRunning}
                     >
-                      {simRunning ? '시뮬레이션 실행 중...' : '🧪 시뮬레이션 실행'}
+                      {simRunning ? '시뮬레이션 진행 중...' : '🧪 시뮬레이션 실행'}
                     </button>
                   )}
                 </div>

--- a/web-client/pages/products/[id].tsx
+++ b/web-client/pages/products/[id].tsx
@@ -68,6 +68,9 @@ export default function ProductDetail() {
   const [faqLoading, setFaqLoading] = useState(false);
   const [faqGenerated, setFaqGenerated] = useState(false);
 
+  const [simMessages, setSimMessages] = useState<{ chatMessages: string[]; faqQuestions: string[] } | null>(null);
+  const [simMsgLoading, setSimMsgLoading] = useState(false);
+
   const [qnaList, setQnaList] = useState<QnAItem[]>([]);
   const [aiInput, setAiInput] = useState('');
   const qnaBottomRef = useRef<HTMLDivElement>(null);
@@ -118,6 +121,18 @@ export default function ProductDetail() {
         if (json?.data?.items?.length > 0) {
           setFaqSamples(json.data.items);
           setFaqGenerated(true);
+        }
+      })
+      .catch(() => {});
+  }, [id]);
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`${API_BASE}/products/${id}/simulation-messages`)
+      .then((res) => res.ok ? res.json() : null)
+      .then((json) => {
+        if (json?.data && (json.data.chatMessages?.length > 0 || json.data.faqQuestions?.length > 0)) {
+          setSimMessages(json.data);
         }
       })
       .catch(() => {});
@@ -177,6 +192,20 @@ export default function ProductDetail() {
         next.delete(documentId);
         return next;
       });
+    }
+  };
+
+  const handleGenerateSimMessages = async () => {
+    setSimMsgLoading(true);
+    try {
+      await fetch(`${API_BASE}/products/${id}/simulation-messages`, { method: 'POST' });
+      const res = await fetch(`${API_BASE}/products/${id}/simulation-messages`);
+      const json = await res.json();
+      if (res.ok && json?.data) setSimMessages(json.data);
+    } catch {
+      // ignore
+    } finally {
+      setSimMsgLoading(false);
     }
   };
 
@@ -344,6 +373,10 @@ export default function ProductDetail() {
         .faq-text.q { color: #cbd5e1; font-weight: 600; }
         .faq-text.a { color: #94a3b8; }
 
+        /* 시뮬레이션 메시지 */
+        .sim-chat-badge { background: rgba(99,102,241,0.2); color: #a5b4fc; border: 1px solid rgba(99,102,241,0.3); }
+        .sim-faq-badge { background: rgba(251,191,36,0.12); color: #fcd34d; border: 1px solid rgba(251,191,36,0.25); }
+
         /* 연결된 방송 */
         .broadcast-list { display: flex; flex-direction: column; gap: 8px; max-height: 320px; overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(255,255,255,0.1) transparent; }
         .broadcast-list::-webkit-scrollbar { width: 4px; }
@@ -499,6 +532,45 @@ export default function ProductDetail() {
                       <div className="faq-row">
                         <span className="faq-badge a">A</span>
                         <span className="faq-text a">{item.answer}</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* 시뮬레이션 메시지 */}
+            <div className="section-card">
+              <div className="section-header">
+                <div>
+                  <div className="section-title">시뮬레이션 메시지</div>
+                  <div className="section-sub">임베딩 기반 LLM이 생성한 시뮬레이션용 채팅·FAQ</div>
+                </div>
+                <button
+                  className="bulk-embed-btn"
+                  onClick={handleGenerateSimMessages}
+                  disabled={simMsgLoading}
+                >
+                  {simMsgLoading ? '생성 중...' : simMessages ? '메시지 추가 생성' : '메시지 생성'}
+                </button>
+              </div>
+              {!simMessages ? (
+                <div className="no-docs">메시지 생성 버튼을 눌러 시뮬레이션 데이터를 준비하세요.</div>
+              ) : (
+                <div className="faq-list">
+                  {simMessages.chatMessages.map((msg, i) => (
+                    <div key={`chat-${i}`} className="faq-item">
+                      <div className="faq-row">
+                        <span className="faq-badge q sim-chat-badge">채팅</span>
+                        <span className="faq-text q">{msg}</span>
+                      </div>
+                    </div>
+                  ))}
+                  {simMessages.faqQuestions.map((q, i) => (
+                    <div key={`faq-${i}`} className="faq-item">
+                      <div className="faq-row">
+                        <span className="faq-badge a sim-faq-badge">FAQ</span>
+                        <span className="faq-text a">{q}</span>
                       </div>
                     </div>
                   ))}


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
라이브 방송 전 호스트가 예상 시청자 채팅을 시뮬레이션할 수 있는 기능을 구현합니다. AI가 상품 정보와 시나리오를 기반으로 시뮬레이션 채팅 메시지를 생성하고, 이를 저장·조회할 수 있습니다.


### Issue
- closes #70


### Why
- 라이브 방송 전 호스트가 시청자 반응을 예측하고 준비할 수 있도록, AI 기반 채팅 시뮬레이션 기능이 필요합니다.
- 방송 준비 단계에서 예상 질문/댓글을 미리 확인해 대응 전략을 세울 수 있습니다.


### What
- **채팅 시뮬레이션 도메인 추가**: `ProductSimulationMessage` 엔티티, `SimulationScenario` 시나리오 모델
- **AI 메시지 생성 유스케이스**: `GenerateSimulationMessagesUseCase` — 상품 정보 기반으로 AI가 채팅 메시지 생성
- **메시지 저장/조회 유스케이스**: `CreateSimulationMessagesUseCase`, `GetSimulationMessagesUseCase`
- **API 엔드포인트 추가**: `ProductController`에 시뮬레이션 메시지 생성 및 조회 API 추가
- **퍼시스턴스 레이어**: `JpaProductSimulationMessageAdapter`, `ProductSimulationMessageRepository`
- **프론트엔드 반영**: 방송 상세(`broadcasts/[id].tsx`) 및 상품 상세(`products/[id].tsx`) 페이지에 시뮬레이션 UI 추가
- **시뮬레이션 서비스**: `SimulationService`, `SimulationController` — 채팅 시뮬레이션 요청 처리


### How
- AI 프롬프트(`SimulationMessages`)와 시나리오(`SimulationScenario`)를 분리해 생성 로직 유연성 확보
- `RestCommerceClient`를 통해 상품 정보를 외부에서 조회해 AI 컨텍스트로 활용
- 헥사고날 아키텍처 준수: 유스케이스 → 포트 → 어댑터 구조로 DB 의존성 격리
- 프론트엔드는 방송 및 상품 상세 페이지에서 시뮬레이션 요청·결과 렌더링


### Test
- 시뮬레이션 메시지 생성 API 호출 후 DB 저장 여부 확인
- 저장된 메시지 조회 API 응답 구조 검증
- 프론트엔드에서 방송/상품 상세 페이지의 시뮬레이션 탭 동작 확인