### PR TITLE
[#74] feat: Redis Pub/Sub 기반 멀티 인스턴스 채팅 브로드캐스트 구현

### DIFF
--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/RedisConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/RedisConfig.java
@@ -8,7 +8,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.RedisSerializer;
 
 @Configuration
@@ -50,9 +49,7 @@ public class RedisConfig {
       RedisConnectionFactory connectionFactory, RoomBroadcastSubscriber subscriber) {
     RedisMessageListenerContainer container = new RedisMessageListenerContainer();
     container.setConnectionFactory(connectionFactory);
-    container.addMessageListener(
-        new MessageListenerAdapter(subscriber, "onMessage"),
-        new PatternTopic(RedisPubSubChannel.roomPattern()));
+    container.addMessageListener(subscriber, new PatternTopic(RedisPubSubChannel.roomPattern()));
     return container;
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/RedisConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/RedisConfig.java
@@ -1,9 +1,14 @@
 package org.giglab.live.infrastructure.redis.config;
 
+import org.giglab.live.infrastructure.redis.pubsub.RedisPubSubChannel;
+import org.giglab.live.infrastructure.redis.pubsub.RoomBroadcastSubscriber;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.RedisSerializer;
 
 @Configuration
@@ -24,5 +29,30 @@ public class RedisConfig {
     template.setHashValueSerializer(jsonRedisSerializer);
     template.afterPropertiesSet();
     return template;
+  }
+
+  // redis pub/sub 은 String 직렬화로 통일 (채널명과 메시지 모두)
+  @Bean
+  public RedisTemplate<String, String> stringRedisTemplate(
+      RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, String> template = new RedisTemplate<>();
+    template.setConnectionFactory(connectionFactory);
+    template.setKeySerializer(RedisSerializer.string());
+    template.setValueSerializer(RedisSerializer.string());
+    template.setHashKeySerializer(RedisSerializer.string());
+    template.setHashValueSerializer(RedisSerializer.string());
+    template.afterPropertiesSet();
+    return template;
+  }
+
+  @Bean
+  public RedisMessageListenerContainer redisMessageListenerContainer(
+      RedisConnectionFactory connectionFactory, RoomBroadcastSubscriber subscriber) {
+    RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+    container.setConnectionFactory(connectionFactory);
+    container.addMessageListener(
+        new MessageListenerAdapter(subscriber, "onMessage"),
+        new PatternTopic(RedisPubSubChannel.roomPattern()));
+    return container;
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RedisPubSubChannel.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RedisPubSubChannel.java
@@ -1,0 +1,22 @@
+package org.giglab.live.infrastructure.redis.pubsub;
+
+public final class RedisPubSubChannel {
+
+  private RedisPubSubChannel() {}
+
+  private static final String ROOM_PREFIX = "LIVE:ROOM:";
+
+  public static String roomChannel(String roomId) {
+    return ROOM_PREFIX + roomId;
+  }
+
+  // RedisMessageListenerContainer 패턴 구독용
+  public static String roomPattern() {
+    return ROOM_PREFIX + "*";
+  }
+
+  // 채널명 → roomId 역변환
+  public static String extractRoomId(String channel) {
+    return channel.substring(ROOM_PREFIX.length());
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastPublisher.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastPublisher.java
@@ -1,0 +1,28 @@
+package org.giglab.live.infrastructure.redis.pubsub;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RoomBroadcastPublisher {
+
+  private final RedisTemplate<String, String> stringRedisTemplate;
+  private final ObjectMapper objectMapper;
+
+  public void publish(String roomId, Object payload) {
+    String channel = RedisPubSubChannel.roomChannel(roomId);
+    try {
+      String json = objectMapper.writeValueAsString(payload);
+      stringRedisTemplate.convertAndSend(channel, json);
+      log.debug("Redis publish - channel={}", channel);
+    } catch (JsonProcessingException e) {
+      log.error("Redis publish 직렬화 실패 - roomId={}", roomId, e);
+    }
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastPublisher.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastPublisher.java
@@ -23,6 +23,8 @@ public class RoomBroadcastPublisher {
       log.debug("Redis publish - channel={}", channel);
     } catch (JsonProcessingException e) {
       log.error("Redis publish 직렬화 실패 - roomId={}", roomId, e);
+    } catch (Exception e) {
+      log.error("Redis publish 실패 - roomId={}, channel={}", roomId, channel, e);
     }
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastSubscriber.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastSubscriber.java
@@ -1,6 +1,7 @@
 package org.giglab.live.infrastructure.redis.pubsub;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
@@ -20,8 +21,8 @@ public class RoomBroadcastSubscriber implements MessageListener {
 
   @Override
   public void onMessage(Message message, byte[] pattern) {
-    String channel = new String(message.getChannel());
-    String body = new String(message.getBody());
+    String channel = new String(message.getChannel(), StandardCharsets.UTF_8);
+    String body = new String(message.getBody(), StandardCharsets.UTF_8);
     String roomId = RedisPubSubChannel.extractRoomId(channel);
 
     try {

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastSubscriber.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastSubscriber.java
@@ -1,0 +1,35 @@
+package org.giglab.live.infrastructure.redis.pubsub;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RoomBroadcastSubscriber implements MessageListener {
+
+  private static final String STOMP_PREFIX = "/sub/room/";
+
+  private final SimpMessagingTemplate messagingTemplate;
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void onMessage(Message message, byte[] pattern) {
+    String channel = new String(message.getChannel());
+    String body = new String(message.getBody());
+    String roomId = RedisPubSubChannel.extractRoomId(channel);
+
+    try {
+      Object payload = objectMapper.readValue(body, Object.class);
+      messagingTemplate.convertAndSend(STOMP_PREFIX + roomId, payload);
+      log.debug("STOMP broadcast - roomId={}", roomId);
+    } catch (Exception e) {
+      log.error("Redis 수신 메시지 처리 실패 - channel={}", channel, e);
+    }
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastSubscriber.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastSubscriber.java
@@ -1,9 +1,11 @@
 package org.giglab.live.infrastructure.redis.pubsub;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.giglab.live.presentation.StompDestination;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -13,8 +15,6 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class RoomBroadcastSubscriber implements MessageListener {
-
-  private static final String STOMP_PREFIX = "/sub/room/";
 
   private final SimpMessagingTemplate messagingTemplate;
   private final ObjectMapper objectMapper;
@@ -26,8 +26,8 @@ public class RoomBroadcastSubscriber implements MessageListener {
     String roomId = RedisPubSubChannel.extractRoomId(channel);
 
     try {
-      Object payload = objectMapper.readValue(body, Object.class);
-      messagingTemplate.convertAndSend(STOMP_PREFIX + roomId, payload);
+      JsonNode payload = objectMapper.readTree(body);
+      messagingTemplate.convertAndSend(StompDestination.ROOM_PREFIX + roomId, payload);
       log.debug("STOMP broadcast - roomId={}", roomId);
     } catch (Exception e) {
       log.error("Redis 수신 메시지 처리 실패 - channel={}", channel, e);

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/StompDestination.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/StompDestination.java
@@ -1,0 +1,8 @@
+package org.giglab.live.presentation;
+
+public final class StompDestination {
+
+  private StompDestination() {}
+
+  public static final String ROOM_PREFIX = "/sub/room/";
+}

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionController.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionController.java
@@ -8,10 +8,10 @@ import org.giglab.live.application.dto.action.ActionRequest;
 import org.giglab.live.application.dto.action.ActionResponse;
 import org.giglab.live.application.service.ChatMessageService;
 import org.giglab.live.application.service.ViewerSessionService;
+import org.giglab.live.infrastructure.redis.pubsub.RoomBroadcastPublisher;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Controller;
 
 @Slf4j
@@ -19,17 +19,16 @@ import org.springframework.stereotype.Controller;
 @RequiredArgsConstructor
 public class RoomActionController {
   private static final String DESTINATION = "/room.action";
-  private static final String SUBSCRIBE_PREFIX = "/sub/room/";
 
   private final ActionDispatcher dispatcher;
-  private final SimpMessageSendingOperations operations;
+  private final RoomBroadcastPublisher publisher;
   private final ChatMessageService chatMessageService;
   private final ViewerSessionService viewerSessionService;
 
   @MessageMapping(DESTINATION)
   public void handle(@Valid ActionRequest req, SimpMessageHeaderAccessor headerAccessor) {
     ActionResponse res = dispatcher.dispatch(req);
-    operations.convertAndSend(SUBSCRIBE_PREFIX + req.roomId(), res);
+    publisher.publish(req.roomId(), res);
     chatMessageService.saveIfNeeded(res);
     try {
       viewerSessionService.saveUserIdIfJoin(req, headerAccessor.getSessionId());

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/event/StompSessionEventListener.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/event/StompSessionEventListener.java
@@ -13,8 +13,8 @@ import org.giglab.live.infrastructure.mongo.MongoPeakViewerSnapshotRepository;
 import org.giglab.live.infrastructure.mongo.MongoViewerSessionRepository;
 import org.giglab.live.infrastructure.redis.ViewerRedisRepository;
 import org.giglab.live.infrastructure.redis.ViewerRedisRepository.ViewerContext;
+import org.giglab.live.infrastructure.redis.pubsub.RoomBroadcastPublisher;
 import org.springframework.context.event.EventListener;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
@@ -25,12 +25,13 @@ import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 @RequiredArgsConstructor
 public class StompSessionEventListener {
 
+  // /sub/room/{roomId} 만 처리, /sub/room/{roomId}/host 등 하위 경로 제외
   private static final String ROOM_DESTINATION_PREFIX = "/sub/room/";
 
   private final ViewerRedisRepository viewerRedisRepository;
   private final MongoViewerSessionRepository viewerSessionRepository;
   private final MongoPeakViewerSnapshotRepository peakViewerSnapshotRepository;
-  private final SimpMessagingTemplate messagingTemplate;
+  private final RoomBroadcastPublisher publisher;
 
   @EventListener
   public void onSubscribe(SessionSubscribeEvent event) {
@@ -108,11 +109,10 @@ public class StompSessionEventListener {
             "action", ActionType.VIEWER_COUNT.getKey(),
             "roomId", roomId,
             "payload", Map.of("count", count));
-    messagingTemplate.convertAndSend(ROOM_DESTINATION_PREFIX + roomId, (Object) message);
+    publisher.publish(roomId, message);
     log.debug("시청자 수 브로드캐스트 - roomId={}, count={}", roomId, count);
   }
 
-  // /sub/room/{roomId} 만 처리, /sub/room/{roomId}/host 등 하위 경로 제외
   private boolean isRoomDestination(String destination) {
     if (!destination.startsWith(ROOM_DESTINATION_PREFIX)) {
       return false;

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/event/StompSessionEventListener.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/event/StompSessionEventListener.java
@@ -14,6 +14,7 @@ import org.giglab.live.infrastructure.mongo.MongoViewerSessionRepository;
 import org.giglab.live.infrastructure.redis.ViewerRedisRepository;
 import org.giglab.live.infrastructure.redis.ViewerRedisRepository.ViewerContext;
 import org.giglab.live.infrastructure.redis.pubsub.RoomBroadcastPublisher;
+import org.giglab.live.presentation.StompDestination;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
@@ -26,7 +27,6 @@ import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 public class StompSessionEventListener {
 
   // /sub/room/{roomId} 만 처리, /sub/room/{roomId}/host 등 하위 경로 제외
-  private static final String ROOM_DESTINATION_PREFIX = "/sub/room/";
 
   private final ViewerRedisRepository viewerRedisRepository;
   private final MongoViewerSessionRepository viewerSessionRepository;
@@ -114,14 +114,14 @@ public class StompSessionEventListener {
   }
 
   private boolean isRoomDestination(String destination) {
-    if (!destination.startsWith(ROOM_DESTINATION_PREFIX)) {
+    if (!destination.startsWith(StompDestination.ROOM_PREFIX)) {
       return false;
     }
-    String path = destination.substring(ROOM_DESTINATION_PREFIX.length());
+    String path = destination.substring(StompDestination.ROOM_PREFIX.length());
     return !path.isEmpty() && !path.contains("/");
   }
 
   private String extractRoomId(String destination) {
-    return destination.substring(ROOM_DESTINATION_PREFIX.length());
+    return destination.substring(StompDestination.ROOM_PREFIX.length());
   }
 }

--- a/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionControllerTest.java
+++ b/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionControllerTest.java
@@ -9,12 +9,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
+import java.util.Objects;
 import org.giglab.live.application.command.ActionDispatcher;
 import org.giglab.live.application.dto.action.ActionRequest;
 import org.giglab.live.application.dto.action.ActionResponse;
 import org.giglab.live.application.dto.action.Actor;
 import org.giglab.live.application.service.ChatMessageService;
 import org.giglab.live.application.service.ViewerSessionService;
+import org.giglab.live.infrastructure.redis.pubsub.RoomBroadcastPublisher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,14 +24,13 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 
 @ExtendWith(MockitoExtension.class)
 class RoomActionControllerTest {
 
   @Mock private ActionDispatcher dispatcher;
 
-  @Mock private SimpMessageSendingOperations messaging;
+  @Mock private RoomBroadcastPublisher publisher;
 
   @Mock private ChatMessageService chatMessageService;
 
@@ -41,9 +42,11 @@ class RoomActionControllerTest {
   @BeforeEach
   void setUp() {
     controller =
-        new RoomActionController(dispatcher, messaging, chatMessageService, viewerSessionService);
+        new RoomActionController(dispatcher, publisher, chatMessageService, viewerSessionService);
     headerAccessor = Mockito.mock(SimpMessageHeaderAccessor.class);
-    Mockito.lenient().when(headerAccessor.getSessionId()).thenReturn("test-session-id");
+    Mockito.lenient()
+        .when(Objects.requireNonNull(headerAccessor.getSessionId()))
+        .thenReturn("test-session-id");
   }
 
   @Test
@@ -59,7 +62,7 @@ class RoomActionControllerTest {
 
     // Then
     verify(dispatcher).dispatch(request);
-    verify(messaging).convertAndSend(eq("/sub/room/ROOM_1"), any(ActionResponse.class));
+    verify(publisher).publish(eq("ROOM_1"), any(ActionResponse.class));
   }
 
   @Test
@@ -75,7 +78,7 @@ class RoomActionControllerTest {
     controller.handle(request, headerAccessor);
 
     // Then
-    verify(messaging).convertAndSend(eq("/sub/room/" + roomId), any(ActionResponse.class));
+    verify(publisher).publish(eq(roomId), any(ActionResponse.class));
   }
 
   @Test
@@ -90,7 +93,7 @@ class RoomActionControllerTest {
     // 단위 테스트에서 직접 handle() 호출 시 예외가 전파됨
     // 실제 Spring STOMP 인프라에서는 @MessageExceptionHandler 가 이를 가로채 세션을 유지함
     assertThrows(IllegalArgumentException.class, () -> controller.handle(request, headerAccessor));
-    verify(messaging, never()).convertAndSend(anyString(), any(ActionResponse.class));
+    verify(publisher, never()).publish(anyString(), any(ActionResponse.class));
   }
 
   @Test
@@ -103,8 +106,7 @@ class RoomActionControllerTest {
     controller.handleException(exception);
 
     // Then
-    verify(messaging, never()).convertAndSend(anyString(), any(ActionResponse.class));
-    verify(messaging, never()).convertAndSendToUser(anyString(), anyString(), any(Object.class));
+    verify(publisher, never()).publish(anyString(), any(ActionResponse.class));
   }
 
   @Test
@@ -119,7 +121,7 @@ class RoomActionControllerTest {
     controller.handle(request, headerAccessor);
 
     // Then
-    verify(messaging).convertAndSend(eq("/sub/room/ROOM_1"), any(ActionResponse.class));
+    verify(publisher).publish(eq("ROOM_1"), any(ActionResponse.class));
   }
 
   @Test
@@ -134,7 +136,7 @@ class RoomActionControllerTest {
     controller.handle(request, headerAccessor);
 
     // Then
-    verify(messaging).convertAndSend(eq("/sub/room/ROOM_1"), any(ActionResponse.class));
+    verify(publisher).publish(eq("ROOM_1"), any(ActionResponse.class));
   }
 
   @Test
@@ -149,7 +151,7 @@ class RoomActionControllerTest {
     controller.handle(request, headerAccessor);
 
     // Then
-    verify(messaging).convertAndSend(eq("/sub/room/ROOM_1"), any(ActionResponse.class));
+    verify(publisher).publish(eq("ROOM_1"), any(ActionResponse.class));
   }
 
   // Helper methods

--- a/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionControllerTest.java
+++ b/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/websocket/RoomActionControllerTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
-import java.util.Objects;
 import org.giglab.live.application.command.ActionDispatcher;
 import org.giglab.live.application.dto.action.ActionRequest;
 import org.giglab.live.application.dto.action.ActionResponse;
@@ -44,9 +43,7 @@ class RoomActionControllerTest {
     controller =
         new RoomActionController(dispatcher, publisher, chatMessageService, viewerSessionService);
     headerAccessor = Mockito.mock(SimpMessageHeaderAccessor.class);
-    Mockito.lenient()
-        .when(Objects.requireNonNull(headerAccessor.getSessionId()))
-        .thenReturn("test-session-id");
+    Mockito.doReturn("test-session-id").when(headerAccessor).getSessionId();
   }
 
   @Test


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
Redis Pub/Sub을 도입해 멀티 인스턴스(스케일 아웃) 환경에서 채팅 메시지와 시청자 수 이벤트가 모든 인스턴스의 클라이언트에게 전달되도록 브로드캐스트 구조를 개선했습니다.


### Issue
- closes #74


### Why
- 기존 Spring STOMP Simple Broker는 in-memory 방식으로, 인스턴스가 2개 이상일 때 각 인스턴스에 연결된 클라이언트에게만 메시지를 전달할 수 있었음
- 수평 확장 시 일부 시청자가 채팅·이벤트 메시지를 수신하지 못하는 문제 해결


### What
- `RedisPubSubChannel`: 채널 네이밍 전략 정의 (`LIVE:ROOM:{roomId}`, 패턴 `LIVE:ROOM:*`)
- `RoomBroadcastPublisher`: `ActionResponse` / `Map` 페이로드를 JSON 직렬화 후 Redis `PUBLISH`
- `RoomBroadcastSubscriber`: Redis 채널 수신 후 `SimpMessagingTemplate`으로 로컬 STOMP 구독자에게 브로드캐스트
- `RedisConfig`: `StringRedisTemplate`(Pub/Sub 전용)과 `RedisMessageListenerContainer`(`LIVE:ROOM:*` 패턴 구독) 빈 등록
- `RoomActionController`: 직접 STOMP 브로드캐스트 → `RoomBroadcastPublisher.publish()` 로 교체
- `StompSessionEventListener`: 시청자 수 브로드캐스트도 Redis 경유로 전환


### How
- Simple Broker는 그대로 유지하고, 인스턴스 간 메시지 전파 계층만 Redis Pub/Sub으로 추가
- 패턴 구독(`LIVE:ROOM:*`)으로 새로운 방 생성 시 재구독 불필요
- Redis → 인스턴스 수만큼만 전달, 각 인스턴스 내 팬아웃은 STOMP Simple Broker가 담당 (O(인스턴스 수))
- Pub/Sub 전용 `RedisTemplate<String, String>` 분리 — 기존 JSON 직렬화 템플릿과 혼용 방지


### Test
- `RoomActionControllerTest`: `SimpMessageSendingOperations` mock → `RoomBroadcastPublisher` mock 으로 교체, `verify(publisher).publish(roomId, ...)` 검증으로 수정
- 로컬 멀티 인스턴스 검증 방법:
  ```bash
  # 인스턴스 A
  ./gradlew :live-chat-server:bootRun --args='--server.port=8080'
  # 인스턴스 B
  ./gradlew :live-chat-server:bootRun --args='--server.port=8081'
  # Redis 채널 모니터링
  redis-cli PSUBSCRIBE "LIVE:ROOM:*"
  ```
  - 탭 1(8080)에서 메시지 전송 → 탭 2(8081) 구독자에게도 수신되면 성공