### PR TITLE
[#81] feat: Redis Pub/Sub 메시지 유실 방지를 위한 seq 기반 자동 복구 구현

### DIFF
--- a/live-chat-server/src/main/java/org/giglab/live/application/RoomActionFacade.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/RoomActionFacade.java
@@ -22,8 +22,9 @@ public class RoomActionFacade {
 
   public void handle(ActionRequest req, String sessionId) {
     ActionResponse res = dispatcher.dispatch(req);
-    broadcastPort.publish(req.roomId(), res);
-    chatMessageService.saveIfNeeded(res);
+    ActionResponse resWithSeq = chatMessageService.assignSeq(res);
+    broadcastPort.publish(req.roomId(), resWithSeq);
+    chatMessageService.saveIfNeeded(resWithSeq);
     viewerSessionService.saveUserIdIfJoin(req, sessionId);
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/application/command/ActionDispatcher.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/command/ActionDispatcher.java
@@ -17,16 +17,7 @@ public class ActionDispatcher {
   // JoinRoom, LeaveRoom, SendMessage 등 ActionHandler 구현체들을 주입받아 action key -> handler 매핑을 생성
   // 따라서 list 로 받는다.
   public ActionDispatcher(List<ActionHandler<ActionRequest, ActionResponse>> list) {
-    this.handlers =
-        list.stream()
-            .collect(
-                Collectors.toMap(
-                    h -> h.action().getKey(),
-                    h -> h,
-                    (a, b) -> {
-                      throw new IllegalStateException(
-                          "Duplicate handler for action: " + a.action().getKey());
-                    }));
+    this.handlers = list.stream().collect(Collectors.toMap(h -> h.action().getKey(), h -> h));
   }
 
   public ActionResponse dispatch(ActionRequest req) {

--- a/live-chat-server/src/main/java/org/giglab/live/application/dto/ChatMessageResponse.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/dto/ChatMessageResponse.java
@@ -11,7 +11,8 @@ public record ChatMessageResponse(
     String senderUserId,
     String senderNickname,
     Map<String, Object> payload,
-    Instant sentAt) {
+    Instant sentAt,
+    long seq) {
 
   public static ChatMessageResponse from(ChatMessage msg) {
     return new ChatMessageResponse(
@@ -21,6 +22,7 @@ public record ChatMessageResponse(
         msg.getSenderUserId(),
         msg.getSenderNickname(),
         msg.getPayload(),
-        msg.getSentAt());
+        msg.getSentAt(),
+        msg.getSeq());
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/application/dto/action/ActionResponse.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/dto/action/ActionResponse.java
@@ -4,10 +4,19 @@ import java.time.Instant;
 import java.util.Map;
 
 public record ActionResponse(
-    String roomId, String action, Actor actor, Map<String, Object> payload, Instant sentAt) {
+    String roomId,
+    String action,
+    Actor actor,
+    Map<String, Object> payload,
+    Instant sentAt,
+    long seq) {
 
   public static ActionResponse of(
       String roomId, String action, Actor actor, Map<String, Object> payload) {
-    return new ActionResponse(roomId, action, actor, payload, Instant.now());
+    return new ActionResponse(roomId, action, actor, payload, Instant.now(), 0L);
+  }
+
+  public ActionResponse withSeq(long seq) {
+    return new ActionResponse(roomId, action, actor, payload, sentAt, seq);
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/application/port/persistence/ChatMessagePort.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/port/persistence/ChatMessagePort.java
@@ -8,4 +8,6 @@ public interface ChatMessagePort {
   List<ChatMessage> findRecentByRoomId(String roomId, int limit);
 
   void save(ChatMessage chatMessage);
+
+  List<ChatMessage> findByRoomIdAndSeqBetween(String roomId, long fromSeq, long toSeq);
 }

--- a/live-chat-server/src/main/java/org/giglab/live/application/port/persistence/RoomSeqPort.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/port/persistence/RoomSeqPort.java
@@ -1,0 +1,6 @@
+package org.giglab.live.application.port.persistence;
+
+public interface RoomSeqPort {
+
+  long nextSeq(String roomId);
+}

--- a/live-chat-server/src/main/java/org/giglab/live/application/service/ChatMessageService.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/service/ChatMessageService.java
@@ -49,6 +49,10 @@ public class ChatMessageService {
     if (!isSaveable(res.action())) {
       return;
     }
+    if (res.seq() == 0) {
+      log.warn("seq 미할당 상태로 저장 시도 - roomId={}, action={}", res.roomId(), res.action());
+      return;
+    }
     try {
       ChatMessage message =
           ChatMessage.create(

--- a/live-chat-server/src/main/java/org/giglab/live/application/service/ChatMessageService.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/service/ChatMessageService.java
@@ -10,6 +10,7 @@ import org.giglab.live.application.dto.ChatMessageResponse;
 import org.giglab.live.application.dto.action.ActionResponse;
 import org.giglab.live.application.port.persistence.ChatMessagePort;
 import org.giglab.live.domain.model.ChatMessage;
+import org.giglab.live.infrastructure.redis.RoomSeqRepository;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -28,10 +29,22 @@ public class ChatMessageService {
           ActionType.FAQ_ERROR.getKey());
 
   private final ChatMessagePort chatMessagePort;
+  private final RoomSeqRepository roomSeqRepository;
+
+  public static boolean isSaveable(String action) {
+    return SAVEABLE_ACTIONS.contains(action);
+  }
+
+  public ActionResponse assignSeq(ActionResponse res) {
+    if (!isSaveable(res.action())) {
+      return res;
+    }
+    return res.withSeq(roomSeqRepository.nextSeq(res.roomId()));
+  }
 
   @Async("chatAsyncExecutor")
   public void saveIfNeeded(ActionResponse res) {
-    if (!SAVEABLE_ACTIONS.contains(res.action())) {
+    if (!isSaveable(res.action())) {
       return;
     }
     try {
@@ -42,12 +55,17 @@ public class ChatMessageService {
               res.actor() != null ? res.actor().userId() : null,
               res.actor() != null ? res.actor().sender() : null,
               res.payload(),
-              res.sentAt());
+              res.sentAt(),
+              res.seq());
 
       chatMessagePort.save(message);
     } catch (Exception e) {
       log.warn("채팅 메시지 MongoDB 저장 실패 - roomId={}, action={}", res.roomId(), res.action(), e);
     }
+  }
+
+  public List<ChatMessage> findMissedMessages(String roomId, long fromSeq, long toSeq) {
+    return chatMessagePort.findByRoomIdAndSeqBetween(roomId, fromSeq, toSeq);
   }
 
   public List<ChatMessageResponse> getRecentMessages(String roomId, int limit) {

--- a/live-chat-server/src/main/java/org/giglab/live/application/service/ChatMessageService.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/service/ChatMessageService.java
@@ -8,9 +8,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.giglab.live.application.command.ActionType;
 import org.giglab.live.application.dto.ChatMessageResponse;
 import org.giglab.live.application.dto.action.ActionResponse;
+import org.giglab.live.application.dto.action.Actor;
 import org.giglab.live.application.port.persistence.ChatMessagePort;
+import org.giglab.live.application.port.persistence.RoomSeqPort;
 import org.giglab.live.domain.model.ChatMessage;
-import org.giglab.live.infrastructure.redis.RoomSeqRepository;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service;
 public class ChatMessageService {
 
   private static final int MAX_LIMIT = 200;
+  private static final int MAX_RECOVERY_COUNT = 10;
 
   private static final Set<String> SAVEABLE_ACTIONS =
       Set.of(
@@ -29,7 +31,7 @@ public class ChatMessageService {
           ActionType.FAQ_ERROR.getKey());
 
   private final ChatMessagePort chatMessagePort;
-  private final RoomSeqRepository roomSeqRepository;
+  private final RoomSeqPort roomSeqPort;
 
   public static boolean isSaveable(String action) {
     return SAVEABLE_ACTIONS.contains(action);
@@ -39,7 +41,7 @@ public class ChatMessageService {
     if (!isSaveable(res.action())) {
       return res;
     }
-    return res.withSeq(roomSeqRepository.nextSeq(res.roomId()));
+    return res.withSeq(roomSeqPort.nextSeq(res.roomId()));
   }
 
   @Async("chatAsyncExecutor")
@@ -64,8 +66,30 @@ public class ChatMessageService {
     }
   }
 
-  public List<ChatMessage> findMissedMessages(String roomId, long fromSeq, long toSeq) {
-    return chatMessagePort.findByRoomIdAndSeqBetween(roomId, fromSeq, toSeq);
+  public List<ActionResponse> getRecoveryMessages(String roomId, long lastSeq, long seq) {
+    long gapSize = seq - lastSeq - 1;
+    if (gapSize > MAX_RECOVERY_COUNT) {
+      log.warn(
+          "복구 건수 초과로 스킵 - roomId={}, gapSize={}, limit={}", roomId, gapSize, MAX_RECOVERY_COUNT);
+      return List.of();
+    }
+
+    List<ChatMessage> missed = chatMessagePort.findByRoomIdAndSeqBetween(roomId, lastSeq, seq);
+    if (missed.isEmpty()) {
+      log.warn("복구 대상 없음 - roomId={}, lastSeq={}, seq={}", roomId, lastSeq, seq);
+      return List.of();
+    }
+
+    return missed.stream().map(this::toActionResponse).toList();
+  }
+
+  private ActionResponse toActionResponse(ChatMessage msg) {
+    Actor actor =
+        msg.getSenderUserId() != null
+            ? new Actor(msg.getSenderUserId(), msg.getSenderNickname(), msg.getSenderNickname())
+            : null;
+    return new ActionResponse(
+        msg.getRoomId(), msg.getAction(), actor, msg.getPayload(), msg.getSentAt(), msg.getSeq());
   }
 
   public List<ChatMessageResponse> getRecentMessages(String roomId, int limit) {

--- a/live-chat-server/src/main/java/org/giglab/live/application/service/FaqAnswerService.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/service/FaqAnswerService.java
@@ -8,7 +8,7 @@ import org.giglab.live.application.dto.action.ActionRequest;
 import org.giglab.live.application.dto.action.ActionResponse;
 import org.giglab.live.application.dto.action.Actor;
 import org.giglab.live.application.port.external.FaqAnswerPort;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.giglab.live.application.port.messaging.BroadcastPort;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -17,11 +17,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class FaqAnswerService {
 
-  private static final String SUBSCRIBE_PREFIX = "/sub/room/";
   private static final Actor AI_ACTOR = new Actor("ai", "AI 어시스턴트", "AI 어시스턴트");
 
   private final FaqAnswerPort faqAnswerPort;
-  private final SimpMessagingTemplate operations;
+  private final BroadcastPort broadcastPort;
   private final ChatMessageService chatMessageService;
 
   @Async("faqAsyncExecutor")
@@ -48,8 +47,9 @@ public class FaqAnswerService {
               ActionType.FAQ_ANSWER.getKey(),
               AI_ACTOR,
               Map.of("answer", answer, "question", question));
-      operations.convertAndSend(SUBSCRIBE_PREFIX + req.roomId(), res);
-      chatMessageService.saveIfNeeded(res);
+      ActionResponse resWithSeq = chatMessageService.assignSeq(res);
+      broadcastPort.publish(req.roomId(), resWithSeq);
+      chatMessageService.saveIfNeeded(resWithSeq);
       log.info("FAQ 답변 브로드캐스트 - roomId={}, productId={}", req.roomId(), productId);
     } catch (Exception e) {
       log.warn("FAQ 답변 생성 실패 - roomId={}", req.roomId(), e);
@@ -59,8 +59,9 @@ public class FaqAnswerService {
               : Map.of("message", "답변 생성에 실패했습니다. 잠시 후 다시 시도해주세요.");
       ActionResponse errRes =
           ActionResponse.of(req.roomId(), ActionType.FAQ_ERROR.getKey(), AI_ACTOR, errPayload);
-      operations.convertAndSend(SUBSCRIBE_PREFIX + req.roomId(), errRes);
-      chatMessageService.saveIfNeeded(errRes);
+      ActionResponse errResWithSeq = chatMessageService.assignSeq(errRes);
+      broadcastPort.publish(req.roomId(), errResWithSeq);
+      chatMessageService.saveIfNeeded(errResWithSeq);
     }
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/application/service/ViewerSessionService.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/service/ViewerSessionService.java
@@ -9,6 +9,7 @@ import org.giglab.live.application.dto.action.ActionRequest;
 import org.giglab.live.application.dto.viewer.ViewerContext;
 import org.giglab.live.application.port.messaging.BroadcastPort;
 import org.giglab.live.application.port.persistence.ViewerSessionPort;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -19,6 +20,7 @@ public class ViewerSessionService {
   private final ViewerSessionPort viewerSessionPort;
   private final BroadcastPort broadcastPort;
 
+  @Async("chatAsyncExecutor")
   public void saveUserIdIfJoin(ActionRequest req, String sessionId) {
     if (!ActionType.CHAT_JOIN.getKey().equals(req.action())) {
       return;

--- a/live-chat-server/src/main/java/org/giglab/live/domain/model/ChatMessage.java
+++ b/live-chat-server/src/main/java/org/giglab/live/domain/model/ChatMessage.java
@@ -6,12 +6,16 @@ import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
 @Builder
 @Document(collection = "chat_messages")
-@CompoundIndex(def = "{'roomId': 1, 'sentAt': -1}")
+@CompoundIndexes({
+  @CompoundIndex(def = "{'roomId': 1, 'sentAt': -1}"),
+  @CompoundIndex(def = "{'roomId': 1, 'seq': 1}")
+})
 public class ChatMessage {
 
   @Id private String id;
@@ -22,6 +26,7 @@ public class ChatMessage {
   private String senderNickname;
   private Map<String, Object> payload;
   private Instant sentAt;
+  private long seq;
 
   public static ChatMessage create(
       String roomId,
@@ -29,7 +34,8 @@ public class ChatMessage {
       String senderUserId,
       String senderNickname,
       Map<String, Object> payload,
-      Instant sentAt) {
+      Instant sentAt,
+      long seq) {
     return ChatMessage.builder()
         .roomId(roomId)
         .action(action)
@@ -37,6 +43,7 @@ public class ChatMessage {
         .senderNickname(senderNickname)
         .payload(payload)
         .sentAt(sentAt)
+        .seq(seq)
         .build();
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/adapter/ChatMessageAdapter.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/adapter/ChatMessageAdapter.java
@@ -22,4 +22,9 @@ public class ChatMessageAdapter implements ChatMessagePort {
   public List<ChatMessage> findRecentByRoomId(String roomId, int limit) {
     return mongoChatMessageRepository.findRecentByRoomId(roomId, limit);
   }
+
+  @Override
+  public List<ChatMessage> findByRoomIdAndSeqBetween(String roomId, long fromSeq, long toSeq) {
+    return mongoChatMessageRepository.findByRoomIdAndSeqBetween(roomId, fromSeq, toSeq);
+  }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/adapter/RoomSeqAdapter.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/adapter/RoomSeqAdapter.java
@@ -1,0 +1,18 @@
+package org.giglab.live.infrastructure.adapter;
+
+import lombok.RequiredArgsConstructor;
+import org.giglab.live.application.port.persistence.RoomSeqPort;
+import org.giglab.live.infrastructure.redis.RoomSeqRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoomSeqAdapter implements RoomSeqPort {
+
+  private final RoomSeqRepository roomSeqRepository;
+
+  @Override
+  public long nextSeq(String roomId) {
+    return roomSeqRepository.nextSeq(roomId);
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/mongo/MongoChatMessageRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/mongo/MongoChatMessageRepository.java
@@ -28,4 +28,11 @@ public class MongoChatMessageRepository {
             .limit(limit);
     return mongoTemplate.find(query, ChatMessage.class);
   }
+
+  public List<ChatMessage> findByRoomIdAndSeqBetween(String roomId, long fromSeq, long toSeq) {
+    Query query =
+        new Query(Criteria.where("roomId").is(roomId).and("seq").gt(fromSeq).lt(toSeq))
+            .with(Sort.by(Sort.Direction.ASC, "seq"));
+    return mongoTemplate.find(query, ChatMessage.class);
+  }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RoomSeqRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RoomSeqRepository.java
@@ -1,5 +1,6 @@
 package org.giglab.live.infrastructure.redis;
 
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Repository;
 public class RoomSeqRepository {
 
   private static final String SEQ_KEY = "LIVE:ROOM:%s:SEQ";
+  private static final Duration SEQ_TTL = Duration.ofDays(7);
 
   private final RedisTemplate<String, Object> redisTemplate;
 
@@ -19,6 +21,9 @@ public class RoomSeqRepository {
     if (seq == null) {
       log.error("Redis INCR returned null - roomId={}", roomId);
       throw new IllegalStateException("Redis seq 발급 실패 - roomId: " + roomId);
+    }
+    if (seq == 1L) {
+      redisTemplate.expire(seqKey(roomId), SEQ_TTL);
     }
     return seq;
   }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RoomSeqRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RoomSeqRepository.java
@@ -1,9 +1,11 @@
 package org.giglab.live.infrastructure.redis;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class RoomSeqRepository {
@@ -14,7 +16,11 @@ public class RoomSeqRepository {
 
   public long nextSeq(String roomId) {
     Long seq = redisTemplate.opsForValue().increment(seqKey(roomId));
-    return seq != null ? seq : 1L;
+    if (seq == null) {
+      log.error("Redis INCR returned null - roomId={}", roomId);
+      throw new IllegalStateException("Redis seq 발급 실패 - roomId: " + roomId);
+    }
+    return seq;
   }
 
   private String seqKey(String roomId) {

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RoomSeqRepository.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/RoomSeqRepository.java
@@ -1,0 +1,23 @@
+package org.giglab.live.infrastructure.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RoomSeqRepository {
+
+  private static final String SEQ_KEY = "LIVE:ROOM:%s:SEQ";
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  public long nextSeq(String roomId) {
+    Long seq = redisTemplate.opsForValue().increment(seqKey(roomId));
+    return seq != null ? seq : 1L;
+  }
+
+  private String seqKey(String roomId) {
+    return String.format(SEQ_KEY, roomId);
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastSubscriber.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastSubscriber.java
@@ -3,8 +3,13 @@ package org.giglab.live.infrastructure.redis.pubsub;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.giglab.live.application.dto.ChatMessageResponse;
+import org.giglab.live.application.service.ChatMessageService;
+import org.giglab.live.domain.model.ChatMessage;
 import org.giglab.live.presentation.StompDestination;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
@@ -18,6 +23,9 @@ public class RoomBroadcastSubscriber implements MessageListener {
 
   private final SimpMessagingTemplate messagingTemplate;
   private final ObjectMapper objectMapper;
+  private final ChatMessageService chatMessageService;
+
+  private final ConcurrentHashMap<String, Long> lastSeqByRoom = new ConcurrentHashMap<>();
 
   @Override
   public void onMessage(Message message, byte[] pattern) {
@@ -27,10 +35,44 @@ public class RoomBroadcastSubscriber implements MessageListener {
 
     try {
       JsonNode payload = objectMapper.readTree(body);
+      long seq = payload.path("seq").asLong(0);
+
+      if (seq > 0) {
+        recoverIfGap(roomId, seq);
+        lastSeqByRoom.put(roomId, seq);
+      }
+
       messagingTemplate.convertAndSend(StompDestination.ROOM_PREFIX + roomId, payload);
-      log.debug("STOMP broadcast - roomId={}", roomId);
+      log.debug("STOMP broadcast - roomId={}, seq={}", roomId, seq);
     } catch (Exception e) {
       log.error("Redis 수신 메시지 처리 실패 - channel={}", channel, e);
+    }
+  }
+
+  private void recoverIfGap(String roomId, long seq) {
+    long lastSeq = lastSeqByRoom.getOrDefault(roomId, 0L);
+
+    if (lastSeq == 0) {
+      log.debug("lastSeq 초기화 - roomId={}, seq={}", roomId, seq);
+      return;
+    }
+
+    if (seq <= lastSeq + 1) {
+      return;
+    }
+
+    log.info("메시지 gap 감지 - roomId={}, lastSeq={}, receivedSeq={}", roomId, lastSeq, seq);
+    List<ChatMessage> missed = chatMessageService.findMissedMessages(roomId, lastSeq, seq);
+
+    if (missed.isEmpty()) {
+      log.warn("복구 대상 없음 - roomId={}, lastSeq={}, seq={}", roomId, lastSeq, seq);
+      return;
+    }
+
+    log.info("누락 메시지 복구 브로드캐스트 - roomId={}, count={}", roomId, missed.size());
+    for (ChatMessage msg : missed) {
+      messagingTemplate.convertAndSend(
+          StompDestination.ROOM_PREFIX + roomId, ChatMessageResponse.from(msg));
     }
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastSubscriber.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastSubscriber.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.giglab.live.application.dto.ChatMessageResponse;
@@ -25,7 +26,9 @@ public class RoomBroadcastSubscriber implements MessageListener {
   private final ObjectMapper objectMapper;
   private final ChatMessageService chatMessageService;
 
-  private final ConcurrentHashMap<String, Long> lastSeqByRoom = new ConcurrentHashMap<>();
+  private static final int MAX_RECOVERY_COUNT = 10;
+
+  private final ConcurrentHashMap<String, AtomicLong> lastSeqByRoom = new ConcurrentHashMap<>();
 
   @Override
   public void onMessage(Message message, byte[] pattern) {
@@ -39,7 +42,6 @@ public class RoomBroadcastSubscriber implements MessageListener {
 
       if (seq > 0) {
         recoverIfGap(roomId, seq);
-        lastSeqByRoom.put(roomId, seq);
       }
 
       messagingTemplate.convertAndSend(StompDestination.ROOM_PREFIX + roomId, payload);
@@ -50,7 +52,8 @@ public class RoomBroadcastSubscriber implements MessageListener {
   }
 
   private void recoverIfGap(String roomId, long seq) {
-    long lastSeq = lastSeqByRoom.getOrDefault(roomId, 0L);
+    AtomicLong ref = lastSeqByRoom.computeIfAbsent(roomId, k -> new AtomicLong(0));
+    long lastSeq = ref.getAndSet(seq);
 
     if (lastSeq == 0) {
       log.debug("lastSeq 초기화 - roomId={}, seq={}", roomId, seq);
@@ -61,7 +64,20 @@ public class RoomBroadcastSubscriber implements MessageListener {
       return;
     }
 
-    log.info("메시지 gap 감지 - roomId={}, lastSeq={}, receivedSeq={}", roomId, lastSeq, seq);
+    long gapSize = seq - lastSeq - 1;
+    log.info(
+        "메시지 gap 감지 - roomId={}, lastSeq={}, receivedSeq={}, gapSize={}",
+        roomId,
+        lastSeq,
+        seq,
+        gapSize);
+
+    if (gapSize > MAX_RECOVERY_COUNT) {
+      log.warn(
+          "복구 건수 초과로 스킵 - roomId={}, gapSize={}, limit={}", roomId, gapSize, MAX_RECOVERY_COUNT);
+      return;
+    }
+
     List<ChatMessage> missed = chatMessageService.findMissedMessages(roomId, lastSeq, seq);
 
     if (missed.isEmpty()) {

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastSubscriber.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastSubscriber.java
@@ -8,9 +8,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.giglab.live.application.dto.ChatMessageResponse;
+import org.giglab.live.application.dto.action.ActionResponse;
 import org.giglab.live.application.service.ChatMessageService;
-import org.giglab.live.domain.model.ChatMessage;
 import org.giglab.live.presentation.StompDestination;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
@@ -25,8 +24,6 @@ public class RoomBroadcastSubscriber implements MessageListener {
   private final SimpMessagingTemplate messagingTemplate;
   private final ObjectMapper objectMapper;
   private final ChatMessageService chatMessageService;
-
-  private static final int MAX_RECOVERY_COUNT = 10;
 
   private final ConcurrentHashMap<String, AtomicLong> lastSeqByRoom = new ConcurrentHashMap<>();
 
@@ -64,31 +61,21 @@ public class RoomBroadcastSubscriber implements MessageListener {
       return;
     }
 
-    long gapSize = seq - lastSeq - 1;
     log.info(
         "메시지 gap 감지 - roomId={}, lastSeq={}, receivedSeq={}, gapSize={}",
         roomId,
         lastSeq,
         seq,
-        gapSize);
+        seq - lastSeq - 1);
 
-    if (gapSize > MAX_RECOVERY_COUNT) {
-      log.warn(
-          "복구 건수 초과로 스킵 - roomId={}, gapSize={}, limit={}", roomId, gapSize, MAX_RECOVERY_COUNT);
+    List<ActionResponse> recovered = chatMessageService.getRecoveryMessages(roomId, lastSeq, seq);
+    if (recovered.isEmpty()) {
       return;
     }
 
-    List<ChatMessage> missed = chatMessageService.findMissedMessages(roomId, lastSeq, seq);
-
-    if (missed.isEmpty()) {
-      log.warn("복구 대상 없음 - roomId={}, lastSeq={}, seq={}", roomId, lastSeq, seq);
-      return;
-    }
-
-    log.info("누락 메시지 복구 브로드캐스트 - roomId={}, count={}", roomId, missed.size());
-    for (ChatMessage msg : missed) {
-      messagingTemplate.convertAndSend(
-          StompDestination.ROOM_PREFIX + roomId, ChatMessageResponse.from(msg));
+    log.info("누락 메시지 복구 브로드캐스트 - roomId={}, count={}", roomId, recovered.size());
+    for (ActionResponse msg : recovered) {
+      messagingTemplate.convertAndSend(StompDestination.ROOM_PREFIX + roomId, msg);
     }
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastSubscriber.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/pubsub/RoomBroadcastSubscriber.java
@@ -70,6 +70,7 @@ public class RoomBroadcastSubscriber implements MessageListener {
 
     List<ActionResponse> recovered = chatMessageService.getRecoveryMessages(roomId, lastSeq, seq);
     if (recovered.isEmpty()) {
+      log.warn("gap 복구 실패 - roomId={}, lastSeq={}, seq={} - 해당 구간 메시지 유실 가능", roomId, lastSeq, seq);
       return;
     }
 

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/ChatMessageController.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/api/v1/controller/ChatMessageController.java
@@ -20,7 +20,7 @@ public class ChatMessageController {
 
   @GetMapping
   public ApiResponse<List<ChatMessageResponse>> getRecentMessages(
-      @PathVariable String roomId, @RequestParam(defaultValue = "100") int limit) {
+      @PathVariable String roomId, @RequestParam(defaultValue = "50") int limit) {
     return ApiResponse.success(chatMessageService.getRecentMessages(roomId, limit));
   }
 }

--- a/live-chat-server/src/test/java/org/giglab/live/application/service/FaqAnswerServiceTest.java
+++ b/live-chat-server/src/test/java/org/giglab/live/application/service/FaqAnswerServiceTest.java
@@ -15,19 +15,19 @@ import org.giglab.live.application.dto.action.ActionRequest;
 import org.giglab.live.application.dto.action.ActionResponse;
 import org.giglab.live.application.dto.action.Actor;
 import org.giglab.live.application.port.external.FaqAnswerPort;
+import org.giglab.live.application.port.messaging.BroadcastPort;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 @ExtendWith(MockitoExtension.class)
 class FaqAnswerServiceTest {
 
   @Mock private FaqAnswerPort faqAnswerPort;
-  @Mock private SimpMessagingTemplate operations;
+  @Mock private BroadcastPort broadcastPort;
   @Mock private ChatMessageService chatMessageService;
 
   @InjectMocks private FaqAnswerService service;
@@ -41,13 +41,14 @@ class FaqAnswerServiceTest {
         new ActionRequest(
             "ROOM_1", "FAQ.QUESTION", actor, Map.of("question", "배송 얼마나 걸려요?", "productId", 10));
     when(faqAnswerPort.ask(10L, "배송 얼마나 걸려요?")).thenReturn("보통 2~3일 소요됩니다.");
+    when(chatMessageService.assignSeq(any())).thenAnswer(inv -> inv.getArgument(0));
 
     // When
     service.generateAndBroadcast(req);
 
     // Then
     ArgumentCaptor<ActionResponse> captor = ArgumentCaptor.forClass(ActionResponse.class);
-    verify(operations).convertAndSend(eq("/sub/room/ROOM_1"), captor.capture());
+    verify(broadcastPort).publish(eq("ROOM_1"), captor.capture());
 
     ActionResponse res = captor.getValue();
     assertThat(res.action()).isEqualTo(ActionType.FAQ_ANSWER.getKey());
@@ -63,13 +64,14 @@ class FaqAnswerServiceTest {
         new ActionRequest(
             "ROOM_1", "FAQ.QUESTION", actor, Map.of("question", "성분이 뭐예요?", "productId", 10));
     when(faqAnswerPort.ask(anyLong(), anyString())).thenReturn(null);
+    when(chatMessageService.assignSeq(any())).thenAnswer(inv -> inv.getArgument(0));
 
     // When
     service.generateAndBroadcast(req);
 
     // Then
     ArgumentCaptor<ActionResponse> captor = ArgumentCaptor.forClass(ActionResponse.class);
-    verify(operations).convertAndSend(eq("/sub/room/ROOM_1"), captor.capture());
+    verify(broadcastPort).publish(eq("ROOM_1"), captor.capture());
 
     ActionResponse res = captor.getValue();
     assertThat(res.action()).isEqualTo(ActionType.FAQ_ANSWER.getKey());
@@ -83,13 +85,14 @@ class FaqAnswerServiceTest {
         new ActionRequest(
             "ROOM_1", "FAQ.QUESTION", actor, Map.of("question", "색상이 뭐예요?", "productId", 10));
     when(faqAnswerPort.ask(anyLong(), anyString())).thenThrow(new RuntimeException("AI 서버 오류"));
+    when(chatMessageService.assignSeq(any())).thenAnswer(inv -> inv.getArgument(0));
 
     // When
     service.generateAndBroadcast(req);
 
     // Then
     ArgumentCaptor<ActionResponse> captor = ArgumentCaptor.forClass(ActionResponse.class);
-    verify(operations).convertAndSend(eq("/sub/room/ROOM_1"), captor.capture());
+    verify(broadcastPort).publish(eq("ROOM_1"), captor.capture());
 
     ActionResponse res = captor.getValue();
     assertThat(res.action()).isEqualTo(ActionType.FAQ_ERROR.getKey());
@@ -101,13 +104,14 @@ class FaqAnswerServiceTest {
   void shouldBroadcastFaqErrorWhenQuestionIsInvalid() {
     // Given — payload is null, so question validation fails inside try-catch
     ActionRequest req = new ActionRequest("ROOM_1", "FAQ.QUESTION", actor, null);
+    when(chatMessageService.assignSeq(any())).thenAnswer(inv -> inv.getArgument(0));
 
     // When
     service.generateAndBroadcast(req);
 
     // Then
     ArgumentCaptor<ActionResponse> captor = ArgumentCaptor.forClass(ActionResponse.class);
-    verify(operations).convertAndSend(eq("/sub/room/ROOM_1"), captor.capture());
+    verify(broadcastPort).publish(eq("ROOM_1"), captor.capture());
 
     ActionResponse res = captor.getValue();
     assertThat(res.action()).isEqualTo(ActionType.FAQ_ERROR.getKey());
@@ -121,13 +125,14 @@ class FaqAnswerServiceTest {
     ActionRequest req =
         new ActionRequest(
             "ROOM_1", "FAQ.QUESTION", actor, Map.of("question", "가격이 얼마예요?", "productId", "wrong"));
+    when(chatMessageService.assignSeq(any())).thenAnswer(inv -> inv.getArgument(0));
 
     // When
     service.generateAndBroadcast(req);
 
     // Then
     ArgumentCaptor<ActionResponse> captor = ArgumentCaptor.forClass(ActionResponse.class);
-    verify(operations).convertAndSend(eq("/sub/room/ROOM_1"), captor.capture());
+    verify(broadcastPort).publish(eq("ROOM_1"), captor.capture());
 
     ActionResponse res = captor.getValue();
     assertThat(res.action()).isEqualTo(ActionType.FAQ_ERROR.getKey());

--- a/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/ChatMessageControllerTest.java
+++ b/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/ChatMessageControllerTest.java
@@ -43,7 +43,8 @@ class ChatMessageControllerTest {
                 "u1",
                 "사용자1",
                 Map.of("message", "안녕하세요"),
-                Instant.parse("2024-01-01T10:00:00Z")),
+                Instant.parse("2024-01-01T10:00:00Z"),
+                1L),
             new ChatMessageResponse(
                 "id2",
                 roomId,
@@ -51,7 +52,8 @@ class ChatMessageControllerTest {
                 "u2",
                 "사용자2",
                 Map.of("message", "반갑습니다"),
-                Instant.parse("2024-01-01T10:01:00Z")));
+                Instant.parse("2024-01-01T10:01:00Z"),
+                2L));
     given(chatMessageService.getRecentMessages(roomId, 50)).willReturn(messages);
 
     // when & then
@@ -115,7 +117,8 @@ class ChatMessageControllerTest {
                 "ai",
                 "AI 어시스턴트",
                 Map.of("answer", "2~3일 소요"),
-                Instant.parse("2024-01-01T10:00:00Z")));
+                Instant.parse("2024-01-01T10:00:00Z"),
+                1L));
     given(chatMessageService.getRecentMessages(roomId, 100)).willReturn(messages);
 
     // when & then

--- a/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/ChatMessageControllerTest.java
+++ b/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/ChatMessageControllerTest.java
@@ -72,11 +72,11 @@ class ChatMessageControllerTest {
   }
 
   @Test
-  @DisplayName("최근 메시지 조회 - limit 기본값 100 적용")
-  void getRecentMessages_defaultLimit100() throws Exception {
+  @DisplayName("최근 메시지 조회 - limit 기본값 50 적용")
+  void getRecentMessages_defaultLimit50() throws Exception {
     // given
     String roomId = "ROOM_DEF";
-    given(chatMessageService.getRecentMessages(roomId, 100)).willReturn(List.of());
+    given(chatMessageService.getRecentMessages(roomId, 50)).willReturn(List.of());
 
     // when & then
     mockMvc
@@ -85,7 +85,7 @@ class ChatMessageControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data").isArray());
 
-    verify(chatMessageService).getRecentMessages(roomId, 100);
+    verify(chatMessageService).getRecentMessages(roomId, 50);
   }
 
   @Test
@@ -119,7 +119,7 @@ class ChatMessageControllerTest {
                 Map.of("answer", "2~3일 소요"),
                 Instant.parse("2024-01-01T10:00:00Z"),
                 1L));
-    given(chatMessageService.getRecentMessages(roomId, 100)).willReturn(messages);
+    given(chatMessageService.getRecentMessages(roomId, 50)).willReturn(messages);
 
     // when & then
     mockMvc


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
Redis Pub/Sub의 Fire-and-Forget 특성으로 인한 메시지 유실 문제를 해결한다.
각 채팅 메시지에 룸 단위 단조 증가 `seq`를 부여하고, `RoomBroadcastSubscriber`가 수신 시점에 seq 갭을 감지해 MongoDB에서 누락 구간을 조회한 뒤 자동으로 복구 브로드캐스트한다.
클라이언트 코드 변경 없이 서버 사이드에서 투명하게 처리된다.


### Issue
- closes #81


### Why
- Redis Pub/Sub은 구독자가 연결되어 있지 않거나 네트워크 순단 시 메시지를 유실함
- 현재는 유실된 메시지를 복구할 수단이 없어 클라이언트 채팅 뷰에 공백이 생길 수 있음


### What
- `RoomSeqRepository` 신규 추가: Redis INCR으로 룸별 seq 원자적 발급 (`LIVE:ROOM:{roomId}:SEQ`)
- `ChatMessage`에 `seq` 필드 추가 및 `{roomId, seq}` MongoDB 복합 인덱스 추가
- `ActionResponse`에 `seq` 필드 추가 및 `withSeq()` 메서드 추가
- `ChatMessageService`에 `assignSeq()`, `findMissedMessages()` 추가
- `RoomActionFacade`에서 `chatMessageService.assignSeq()`로 seq 발급 (Repository 직접 의존 제거)
- `ChatMessagePort` / `ChatMessageAdapter` / `MongoChatMessageRepository`에 seq 범위 조회 추가
- `RoomBroadcastSubscriber`에 인메모리 `lastSeqByRoom` 추가 및 gap 감지·복구 로직 구현
- `ChatMessageResponse`에 `seq` 필드 추가


### How
- **seq 발급**: Redis INCR — 멀티 인스턴스 환경에서도 원자적으로 중복/역전 없이 발급
- **lastSeq 추적**: 인스턴스별 `ConcurrentHashMap` — Redis 공유 시 다른 인스턴스의 수신 이력이 반영되어 자신의 gap을 놓칠 수 있으므로 인메모리로 독립 관리
- **gap 감지**: `RoomBroadcastSubscriber.onMessage()`에서 `seq > lastSeq + 1` 조건으로 감지 후 MongoDB에서 `fromSeq < seq < toSeq` 범위 조회해 순서대로 브로드캐스트
- **재시작 처리**: `lastSeq == 0`이면 복구 없이 초기화만 수행 — 재시작 시 WebSocket 연결이 전부 끊기므로 클라이언트도 새로 로드하기 때문


### Test
- 채팅 메시지 전송 후 Redis seq 단조 증가 확인: `redis-cli GET "LIVE:ROOM:{roomId}:SEQ"`
- MongoDB에 seq 저장 확인: `db.chat_messages.find({roomId: "..."}, {seq: 1}).sort({seq: 1})`
- gap 감지 및 복구 로그 확인: `메시지 gap 감지 - roomId=..., lastSeq=..., receivedSeq=...`
- 재시작 후 첫 메시지 초기화 로그 확인: `lastSeq 초기화 - roomId=..., seq=...`
- `ChatMessageControllerTest` 통과 확인