### PR TITLE
[#83] refactor: RoomBroadcastSubscriber를 presentation/subscriber로 이동

### DIFF
--- a/live-chat-server/src/main/java/org/giglab/live/global/config/RedisPubSubConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/global/config/RedisPubSubConfig.java
@@ -1,0 +1,22 @@
+package org.giglab.live.global.config;
+
+import org.giglab.live.infrastructure.redis.pubsub.RedisPubSubChannel;
+import org.giglab.live.presentation.subscriber.RoomBroadcastSubscriber;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+public class RedisPubSubConfig {
+
+  @Bean
+  public RedisMessageListenerContainer redisMessageListenerContainer(
+      RedisConnectionFactory connectionFactory, RoomBroadcastSubscriber subscriber) {
+    RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+    container.setConnectionFactory(connectionFactory);
+    container.addMessageListener(subscriber, new PatternTopic(RedisPubSubChannel.roomPattern()));
+    return container;
+  }
+}

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/RedisConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/RedisConfig.java
@@ -1,13 +1,9 @@
 package org.giglab.live.infrastructure.redis.config;
 
-import org.giglab.live.infrastructure.redis.pubsub.RedisPubSubChannel;
-import org.giglab.live.presentation.subscriber.RoomBroadcastSubscriber;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.listener.PatternTopic;
-import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.RedisSerializer;
 
 @Configuration
@@ -42,14 +38,5 @@ public class RedisConfig {
     template.setHashValueSerializer(RedisSerializer.string());
     template.afterPropertiesSet();
     return template;
-  }
-
-  @Bean
-  public RedisMessageListenerContainer redisMessageListenerContainer(
-      RedisConnectionFactory connectionFactory, RoomBroadcastSubscriber subscriber) {
-    RedisMessageListenerContainer container = new RedisMessageListenerContainer();
-    container.setConnectionFactory(connectionFactory);
-    container.addMessageListener(subscriber, new PatternTopic(RedisPubSubChannel.roomPattern()));
-    return container;
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/RedisConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/infrastructure/redis/config/RedisConfig.java
@@ -1,7 +1,7 @@
 package org.giglab.live.infrastructure.redis.config;
 
 import org.giglab.live.infrastructure.redis.pubsub.RedisPubSubChannel;
-import org.giglab.live.infrastructure.redis.pubsub.RoomBroadcastSubscriber;
+import org.giglab.live.presentation.subscriber.RoomBroadcastSubscriber;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/subscriber/RoomBroadcastSubscriber.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/subscriber/RoomBroadcastSubscriber.java
@@ -1,4 +1,4 @@
-package org.giglab.live.infrastructure.redis.pubsub;
+package org.giglab.live.presentation.subscriber;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.giglab.live.application.dto.action.ActionResponse;
 import org.giglab.live.application.service.ChatMessageService;
+import org.giglab.live.infrastructure.redis.pubsub.RedisPubSubChannel;
 import org.giglab.live.presentation.StompDestination;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
Redis Pub/Sub 도입으로 어긋난 패키지 구조를 헥사고날 아키텍처 기준으로 정비한다. `RoomBroadcastSubscriber`를 `infrastructure/redis/pubsub/`에서 `presentation/subscriber/`로 이동해 inbound 어댑터가 올바른 위치에 배치되도록 한다.


### Issue
- closes #83


### Why
- `RoomBroadcastSubscriber`는 Redis로부터 메시지를 **수신**해 애플리케이션을 호출하는 inbound 어댑터임
- 그러나 `infrastructure/` 레이어는 애플리케이션이 **호출하는** outbound 방향 코드가 모여 있어 방향이 엇갈림
- 현재 `presentation/`에는 REST 컨트롤러, STOMP 핸들러, 세션 이벤트 리스너 등 모든 inbound 진입점이 모여 있으므로, subscriber도 동일한 기준을 따르는 것이 일관성 있음


### What
- `RoomBroadcastSubscriber` 패키지 이동: `infrastructure.redis.pubsub` → `presentation.subscriber`
- `RedisConfig`의 `RoomBroadcastSubscriber` import 경로 수정


### How
- `presentation/subscriber/` 신규 패키지에 파일 이동 및 패키지 선언 변경
- `RedisPubSubChannel`(채널명 유틸리티)은 infrastructure에 그대로 유지 — subscriber가 infrastructure 유틸을 참조하는 것은 inbound→outbound 방향으로 허용 범위
- `RedisConfig`(infrastructure)가 `RoomBroadcastSubscriber`(presentation)를 주입받는 구조는 Spring 설정 코드로서 레이어 규칙 예외 적용

**이동 후 presentation 구조:**
```
presentation/
├── api/v1/controller/           ← HTTP inbound
├── api/v1/controller/websocket/ ← STOMP inbound
├── event/                       ← STOMP 세션 이벤트 inbound
└── subscriber/                  ← Redis Pub/Sub inbound ✅
```


### Test
- `./gradlew :live-chat-server:test` 전체 통과 확인
- 기능 변경 없음 — 패키지 이동만 수행