### PR TITLE
[#88] feat: Kafka, ClickHouse, Vector 기반 이벤트 수집 파이프라인 컴포즈 구성

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,11 @@ collector-up: network-create
 collector-down:
 	@docker-compose -f docker-compose.collector.yml down
 
+kafka-init:
+	docker exec live-platform-kafka /opt/kafka/bin/kafka-topics.sh \
+		--bootstrap-server localhost:9092 --create --if-not-exists \
+		--topic live-events --partitions 3 --replication-factor 1
+
 docker-mysql-up:
 	@docker-compose -f docker-compose.infra.yml up -d mysql
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,15 @@ infra-up:
 infra-down:
 	@docker-compose -f docker-compose.infra.yml down
 
+network-create:
+	@docker network inspect live-platform-network >/dev/null 2>&1 || docker network create live-platform-network
+
+collector-up: network-create
+	@docker-compose -f docker-compose.collector.yml up -d
+
+collector-down:
+	@docker-compose -f docker-compose.collector.yml down
+
 docker-mysql-up:
 	@docker-compose -f docker-compose.infra.yml up -d mysql
 

--- a/config/clickhouse/init.sql
+++ b/config/clickhouse/init.sql
@@ -2,13 +2,14 @@ CREATE DATABASE IF NOT EXISTS analytics;
 
 CREATE TABLE IF NOT EXISTS analytics.events
 (
-    event_id     String,
-    event_type   LowCardinality(String),
-    occurred_at  DateTime64(3, 'UTC'),
-    session_id   String,
-    user_id      Nullable(String),
-    room_id      String,
-    properties   String
-) ENGINE = MergeTree()
+    event_id       String,
+    event_type     LowCardinality(String),
+    occurred_at    DateTime64(3, 'UTC'),
+    occurred_at_ms UInt64,
+    session_id     String,
+    user_id        Nullable(String),
+    room_id        String,
+    properties     String
+) ENGINE = ReplacingMergeTree(occurred_at_ms)
 PARTITION BY toYYYYMM(occurred_at)
-ORDER BY (room_id, event_type, occurred_at);
+ORDER BY (room_id, event_type, occurred_at, event_id);

--- a/config/clickhouse/init.sql
+++ b/config/clickhouse/init.sql
@@ -1,0 +1,14 @@
+CREATE DATABASE IF NOT EXISTS analytics;
+
+CREATE TABLE IF NOT EXISTS analytics.events
+(
+    event_id     String,
+    event_type   LowCardinality(String),
+    occurred_at  DateTime64(3, 'UTC'),
+    session_id   String,
+    user_id      Nullable(String),
+    room_id      String,
+    properties   String
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(occurred_at)
+ORDER BY (room_id, event_type, occurred_at);

--- a/config/vector/vector.toml
+++ b/config/vector/vector.toml
@@ -1,0 +1,37 @@
+[sources.kafka_live_events]
+type = "kafka"
+bootstrap_servers = "kafka:9092"
+topics = ["live-events"]
+group_id = "vector-clickhouse-group"
+auto_offset_reset = "earliest"
+
+[transforms.parse_event]
+type = "remap"
+inputs = ["kafka_live_events"]
+source = '''
+  parsed = parse_json!(.message)
+  .event_id    = parsed.event_id
+  .event_type  = parsed.event_type
+  .occurred_at = parsed.occurred_at
+  .session_id  = parsed.session_id
+  .user_id     = parsed.user_id
+  .room_id     = parsed.room_id
+  .properties  = encode_json(parsed.properties)
+'''
+
+[sinks.clickhouse_events]
+type = "clickhouse"
+inputs = ["parse_event"]
+endpoint = "http://clickhouse:8123"
+database = "analytics"
+table = "events"
+skip_unknown_fields = true
+
+[sinks.clickhouse_events.batch]
+max_bytes = 10485760
+timeout_secs = 5
+
+[sinks.clickhouse_events.buffer]
+type = "disk"
+max_size = 268435456
+when_full = "block"

--- a/config/vector/vector.toml
+++ b/config/vector/vector.toml
@@ -10,13 +10,14 @@ type = "remap"
 inputs = ["kafka_live_events"]
 source = '''
   parsed = parse_json!(.message)
-  .event_id    = parsed.event_id
-  .event_type  = parsed.event_type
-  .occurred_at = parsed.occurred_at
-  .session_id  = parsed.session_id
-  .user_id     = parsed.user_id
-  .room_id     = parsed.room_id
-  .properties  = encode_json(parsed.properties)
+  .event_id       = parsed.event_id
+  .event_type     = parsed.event_type
+  .occurred_at    = parsed.occurred_at
+  .occurred_at_ms = to_unix_timestamp_millis!(parse_timestamp!(parsed.occurred_at, format: "%+"))
+  .session_id     = parsed.session_id
+  .user_id        = parsed.user_id
+  .room_id        = parsed.room_id
+  .properties     = encode_json(parsed.properties)
 '''
 
 [sinks.clickhouse_events]

--- a/config/vector/vector.toml
+++ b/config/vector/vector.toml
@@ -27,6 +27,11 @@ database = "analytics"
 table = "events"
 skip_unknown_fields = true
 
+[sinks.clickhouse_events.auth]
+strategy = "basic"
+user = "${CLICKHOUSE_USER}"
+password = "${CLICKHOUSE_PASSWORD}"
+
 [sinks.clickhouse_events.batch]
 max_bytes = 10485760
 timeout_secs = 5

--- a/docker-compose.collector.yml
+++ b/docker-compose.collector.yml
@@ -22,7 +22,7 @@ services:
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
 
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
       KAFKA_NUM_PARTITIONS: 3
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
@@ -60,9 +60,8 @@ services:
     ports:
       - "8123:8123"
       - "9000:9000"
+    env_file: .env
     environment:
-      CLICKHOUSE_USER: default
-      CLICKHOUSE_PASSWORD: clickhouse
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
     volumes:
       - clickhouse_data:/var/lib/clickhouse
@@ -82,6 +81,7 @@ services:
   vector:
     image: timberio/vector:0.38.0-alpine
     container_name: live-platform-vector
+    env_file: .env
     volumes:
       - ./config/vector/vector.toml:/etc/vector/vector.toml:ro
       - vector_buffer:/var/lib/vector

--- a/docker-compose.collector.yml
+++ b/docker-compose.collector.yml
@@ -40,7 +40,7 @@ services:
     restart: unless-stopped
 
   kafka-ui:
-    image: provectuslabs/kafka-ui:latest
+    image: provectuslabs/kafka-ui:v0.7.2
     container_name: live-platform-kafka-ui
     ports:
       - "8081:8080"

--- a/docker-compose.collector.yml
+++ b/docker-compose.collector.yml
@@ -1,0 +1,105 @@
+version: '3.8'
+
+services:
+  kafka:
+    image: apache/kafka:3.7.0
+    container_name: live-platform-kafka
+    hostname: kafka
+    ports:
+      - "9092:9092"
+      - "9094:9094"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+
+      # Controller quorum
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+
+      # Listeners
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:9094
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_NUM_PARTITIONS: 3
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+    volumes:
+      - kafka_data:/var/lib/kafka/data
+    networks:
+      - live-platform-network
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: live-platform-kafka-ui
+    ports:
+      - "8081:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+    depends_on:
+      kafka:
+        condition: service_healthy
+    networks:
+      - live-platform-network
+    restart: unless-stopped
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.3
+    container_name: live-platform-clickhouse
+    hostname: clickhouse
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    environment:
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: clickhouse
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+    volumes:
+      - clickhouse_data:/var/lib/clickhouse
+      - ./config/clickhouse/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    networks:
+      - live-platform-network
+    healthcheck:
+      test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+
+  vector:
+    image: timberio/vector:0.38.0-alpine
+    container_name: live-platform-vector
+    volumes:
+      - ./config/vector/vector.toml:/etc/vector/vector.toml:ro
+      - vector_buffer:/var/lib/vector
+    command: ["--config", "/etc/vector/vector.toml"]
+    depends_on:
+      kafka:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+    networks:
+      - live-platform-network
+    restart: unless-stopped
+
+volumes:
+  kafka_data:
+  clickhouse_data:
+  vector_buffer:
+
+networks:
+  live-platform-network:
+    external: true

--- a/docker-compose.collector.yml
+++ b/docker-compose.collector.yml
@@ -37,6 +37,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 5
+    restart: unless-stopped
 
   kafka-ui:
     image: provectuslabs/kafka-ui:latest
@@ -69,7 +70,7 @@ services:
     networks:
       - live-platform-network
     healthcheck:
-      test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1'"]
+      test: ["CMD-SHELL", "clickhouse-client --user $${CLICKHOUSE_USER} --password $${CLICKHOUSE_PASSWORD} --query 'SELECT 1'"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -77,6 +78,7 @@ services:
       nofile:
         soft: 262144
         hard: 262144
+    restart: unless-stopped
 
   vector:
     image: timberio/vector:0.38.0-alpine


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
Kafka → Vector → ClickHouse로 이어지는 이벤트 수집 파이프라인을 Docker Compose로 구성합니다. 기존 인프라(live-platform-network)와 독립적으로 단독 실행도 가능하도록 Makefile에 네트워크 자동 생성 로직을 추가합니다.


### Issue
- closes #88


### Why
- 라이브 채팅 서버에서 발생하는 이벤트(입장, 퇴장, 메시지 등)를 분석용 저장소에 수집할 파이프라인이 필요
- 실시간 스트리밍 데이터를 ClickHouse에 효율적으로 적재하기 위한 인프라 구성


### What
- `docker-compose.collector.yml`: Kafka(KRaft), Kafka UI, ClickHouse, Vector 컨테이너 정의
- `config/vector/vector.toml`: Kafka `live-events` 토픽 → JSON 파싱 → ClickHouse `analytics.events` 테이블 배치 적재 파이프라인
- `config/clickhouse/init.sql`: `analytics` DB 및 `events` 테이블 DDL (MergeTree, 월별 파티셔닝)
- `Makefile`: `network-create` 타겟 추가 및 `collector-up` 의존성 설정으로 단독 실행 지원


### How
- Kafka: `apache/kafka:3.7.0` KRaft 모드 (ZooKeeper 없이 단일 브로커)
- Vector: Kafka source → remap transform(VRL) → ClickHouse sink, 디스크 버퍼(256MB)로 ClickHouse 장애 시 데이터 유실 방지
- ClickHouse: `events` 테이블을 `(room_id, event_type, occurred_at)` 기준 정렬, 월별 파티셔닝으로 조회 성능 최적화
- 네트워크: `live-platform-network`를 external로 선언, `make collector-up` 실행 시 네트워크가 없으면 자동 생성


### Test
- `make collector-up` 단독 실행 → Kafka, ClickHouse, Vector 컨테이너 정상 기동 확인
- IntelliJ Database 탭에서 `localhost:8123`으로 ClickHouse 접속 및 `analytics.events` 테이블 생성 확인