### PR TITLE
[#97] perf: Kafka Producer batch.size 32KB, snappy 압축 추가

### DIFF
--- a/live-event-collector/src/main/java/org/giglab/live/collector/infrastructure/kafka/config/KafkaConfig.java
+++ b/live-event-collector/src/main/java/org/giglab/live/collector/infrastructure/kafka/config/KafkaConfig.java
@@ -36,6 +36,15 @@ public class KafkaConfig {
     // 메시지를 배치로 묶어서 전송하는 지연 시간 설정 (ms 단위)
     // 이 값이 크면 메시지를 더 많이 배치로 묶어서 자원을 효율적으로 쓰지만 지연이 발생할 수 있음
     config.put(ProducerConfig.LINGER_MS_CONFIG, 5);
+    // 기본 16kb 배치 사이즈를 32kb로 늘려서 네트워크 효율성 향상
+    // 이벤트 크기 420bytes, kafka-ui 에서 확인
+    // 32 * 1024 = 32768 bytes, 32768 / 420 ≈ 78.02
+    // 32kb 배치 사이즈면 평균적으로 80개 이상의 이벤트를 한 번에 전송 가능
+    config.put(ProducerConfig.BATCH_SIZE_CONFIG, 32 * 1024);
+    // 메시지 압축 설정
+    // snappy: 압축률 중간 → CPU 낮음 → 처리량 유지
+    // gzip: 압축률 높음 → CPU 높음 → 처리량 감소 가능
+    config.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
     return new DefaultKafkaProducerFactory<>(config);
   }
 


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
Kafka Producer에 `batch.size=32KB`와 `compression.type=snappy`를 추가해 네트워크 대역폭과 브로커 부하를 줄입니다.


### Issue
- closes #97


### Why
- `batch.size` 미설정(기본 16KB)으로 이벤트 수집기 특성에 비해 배치가 작게 묶임
- 압축 미설정으로 평균 427바이트의 이벤트 JSON이 그대로 전송되어 네트워크 대역폭 낭비
- 실측 이벤트 크기 427바이트 기준, 32KB 배치 = 약 80개 이벤트로 linger.ms=5와 적절히 조합됨


### What
- `ProducerConfig.BATCH_SIZE_CONFIG = 32 * 1024` (32KB) 추가
- `ProducerConfig.COMPRESSION_TYPE_CONFIG = "snappy"` 추가


### How
- snappy 선택 이유: gzip 대비 CPU 비용 낮음 / lz4 대비 Kafka 호환성 안정적 / JSON 텍스트 반복 패턴에 40~60% 압축률
- batch.size=32KB: 이벤트 평균 400바이트 기준 약 80개 배치, 트래픽 폭증 시 배치 효율 향상 / linger.ms 타임아웃이 먼저 걸려도 손해 없음
- snappy는 `spring-kafka`가 포함한 `xerial/snappy-java`로 동작하므로 별도 의존성 불필요


### Test
- `./gradlew :live-event-collector:build` → BUILD SUCCESSFUL
- 이벤트 전송 후 kafka-ui(`http://localhost:8081`) `live-events` 토픽에서 메시지 정상 적재 확인
- ClickHouse에 이벤트 정상 적재 확인 (압축은 Producer↔Broker 간이므로 Consumer 측 데이터 영향 없음)