### PR TITLE
[#108] refactor: Java 25 업그레이드 및 모던 Java 기능 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ subprojects {
     
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
+            languageVersion = JavaLanguageVersion.of(25)
         }
     }
 

--- a/live-chat-server/Dockerfile
+++ b/live-chat-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:8.14-jdk21 AS build
+FROM gradle:8.14-jdk25 AS build
 
 WORKDIR /app
 
@@ -18,7 +18,7 @@ RUN gradle :live-chat-server:bootJar --no-daemon
 
 RUN test -f live-chat-server/build/libs/*.jar || (echo "JAR file not found" && exit 1)
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 
 RUN addgroup -S live && adduser -S live -G live
 

--- a/live-chat-server/src/main/java/org/giglab/live/application/dto/action/ActionResponse.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/dto/action/ActionResponse.java
@@ -18,7 +18,8 @@ import java.util.Map;
   @JsonSubTypes.Type(value = ShowBannerResponse.class, name = "PRODUCT.BANNER.ON"),
   @JsonSubTypes.Type(value = HideBannerResponse.class, name = "PRODUCT.BANNER.OFF"),
 })
-public interface ActionResponse {
+public sealed interface ActionResponse
+    permits DefaultActionResponse, JoinRoomResponse, ShowBannerResponse, HideBannerResponse {
 
   String roomId();
 

--- a/live-chat-server/src/main/java/org/giglab/live/application/dto/room/CreateRoomRequest.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/dto/room/CreateRoomRequest.java
@@ -2,14 +2,6 @@ package org.giglab.live.application.dto.room;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.Setter;
 
-@Getter
-@Setter
-public class CreateRoomRequest {
-
-  @NotBlank
-  @Size(max = 50, message = "채팅방 이름은 50자를 초과할 수 없습니다.")
-  private String title;
-}
+public record CreateRoomRequest(
+    @NotBlank @Size(max = 50, message = "채팅방 이름은 50자를 초과할 수 없습니다.") String title) {}

--- a/live-chat-server/src/main/java/org/giglab/live/application/dto/room/GetRoomResponse.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/dto/room/GetRoomResponse.java
@@ -1,15 +1,8 @@
 package org.giglab.live.application.dto.room;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.giglab.live.domain.model.Room;
 
-@Getter
-@AllArgsConstructor
-public class GetRoomResponse {
-
-  private String roomId;
-  private String title;
+public record GetRoomResponse(String roomId, String title) {
 
   public static GetRoomResponse from(Room room) {
     return new GetRoomResponse(room.getRoomId(), room.getTitle());

--- a/live-chat-server/src/main/java/org/giglab/live/application/service/RoomService.java
+++ b/live-chat-server/src/main/java/org/giglab/live/application/service/RoomService.java
@@ -28,7 +28,7 @@ public class RoomService {
   private final RoomPort roomPort;
 
   public CreateRoomResponse createRoom(CreateRoomRequest request) {
-    Room room = Room.create(request.getTitle());
+    Room room = Room.create(request.title());
     Room saved = roomPort.save(room);
     return new CreateRoomResponse(
         saved.getRoomId(), saved.getTitle(), saved.getCreatedAt(), saved.getUpdatedAt());

--- a/live-chat-server/src/main/java/org/giglab/live/global/config/AsyncConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/global/config/AsyncConfig.java
@@ -1,65 +1,22 @@
 package org.giglab.live.global.config;
 
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
-import java.util.concurrent.ThreadPoolExecutor;
-import org.springframework.beans.factory.annotation.Value;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @EnableAsync
 @Configuration
 public class AsyncConfig {
 
-  @Value("${async.faq.core-pool-size}")
-  private int faqCorePoolSize;
-
-  @Value("${async.faq.max-pool-size}")
-  private int faqMaxPoolSize;
-
-  @Value("${async.faq.queue-capacity}")
-  private int faqQueueCapacity;
-
-  @Value("${async.chat.core-pool-size}")
-  private int chatCorePoolSize;
-
-  @Value("${async.chat.max-pool-size}")
-  private int chatMaxPoolSize;
-
-  @Value("${async.chat.queue-capacity}")
-  private int chatQueueCapacity;
-
   @Bean(name = "faqAsyncExecutor")
-  public ThreadPoolTaskExecutor faqAsyncExecutor(MeterRegistry meterRegistry) {
-    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-    executor.setCorePoolSize(faqCorePoolSize);
-    executor.setMaxPoolSize(faqMaxPoolSize);
-    executor.setQueueCapacity(faqQueueCapacity);
-    executor.setThreadNamePrefix("faq-async-");
-    executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
-    executor.initialize();
-
-    ExecutorServiceMetrics.monitor(
-        meterRegistry, executor.getThreadPoolExecutor(), "faq_async_executor");
-
-    return executor;
+  public Executor faqAsyncExecutor() {
+    return Executors.newVirtualThreadPerTaskExecutor();
   }
 
   @Bean(name = "chatAsyncExecutor")
-  public ThreadPoolTaskExecutor chatAsyncExecutor(MeterRegistry meterRegistry) {
-    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-    executor.setCorePoolSize(chatCorePoolSize);
-    executor.setMaxPoolSize(chatMaxPoolSize);
-    executor.setQueueCapacity(chatQueueCapacity);
-    executor.setThreadNamePrefix("chat-async-");
-    executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
-    executor.initialize();
-
-    ExecutorServiceMetrics.monitor(
-        meterRegistry, executor.getThreadPoolExecutor(), "chat_async_executor");
-
-    return executor;
+  public Executor chatAsyncExecutor() {
+    return Executors.newVirtualThreadPerTaskExecutor();
   }
 }

--- a/live-chat-server/src/main/java/org/giglab/live/global/config/AsyncConfig.java
+++ b/live-chat-server/src/main/java/org/giglab/live/global/config/AsyncConfig.java
@@ -1,6 +1,8 @@
 package org.giglab.live.global.config;
 
-import java.util.concurrent.Executor;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,13 +12,17 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @Configuration
 public class AsyncConfig {
 
-  @Bean(name = "faqAsyncExecutor")
-  public Executor faqAsyncExecutor() {
-    return Executors.newVirtualThreadPerTaskExecutor();
+  @Bean(name = "faqAsyncExecutor", destroyMethod = "shutdown")
+  public ExecutorService faqAsyncExecutor(MeterRegistry meterRegistry) {
+    var executor =
+        Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("faq-async-", 0).factory());
+    return ExecutorServiceMetrics.monitor(meterRegistry, executor, "faq_async_executor");
   }
 
-  @Bean(name = "chatAsyncExecutor")
-  public Executor chatAsyncExecutor() {
-    return Executors.newVirtualThreadPerTaskExecutor();
+  @Bean(name = "chatAsyncExecutor", destroyMethod = "shutdown")
+  public ExecutorService chatAsyncExecutor(MeterRegistry meterRegistry) {
+    var executor =
+        Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("chat-async-", 0).factory());
+    return ExecutorServiceMetrics.monitor(meterRegistry, executor, "chat_async_executor");
   }
 }

--- a/live-chat-server/src/main/resources/application.yml
+++ b/live-chat-server/src/main/resources/application.yml
@@ -7,6 +7,9 @@ spring:
   data:
     mongodb:
       uri: ${MONGODB_URI}
+  threads:
+    virtual:
+      enabled: true
 
 management:
   endpoints:
@@ -25,15 +28,6 @@ commerce-core:
     max-connections: 50     # 전체 커넥션 풀 크기
     max-connections-per-route: 20  # 단일 호스트 최대 연결 수
 
-async:
-  faq:
-    core-pool-size: 5
-    max-pool-size: 20
-    queue-capacity: 100
-  chat:
-    core-pool-size: 2
-    max-pool-size: 5
-    queue-capacity: 500
 
 logging:
   level:

--- a/live-chat-server/src/test/java/org/giglab/live/application/dto/action/ActionResponseTest.java
+++ b/live-chat-server/src/test/java/org/giglab/live/application/dto/action/ActionResponseTest.java
@@ -1,0 +1,30 @@
+package org.giglab.live.application.dto.action;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ActionResponseTest {
+
+  @Test
+  @DisplayName("sealed permits 목록과 @JsonSubTypes 타입이 일치해야 합니다")
+  void permitsAndJsonSubTypesShouldBeInSync() {
+    Set<Class<?>> permittedTypes =
+        Arrays.stream(ActionResponse.class.getPermittedSubclasses()).collect(Collectors.toSet());
+
+    JsonSubTypes jsonSubTypes = ActionResponse.class.getAnnotation(JsonSubTypes.class);
+    Set<Class<?>> jsonSubTypesClasses =
+        Arrays.stream(jsonSubTypes.value())
+            .map(JsonSubTypes.Type::value)
+            .collect(Collectors.toSet());
+
+    assertThat(permittedTypes)
+        .as("sealed permits 목록과 @JsonSubTypes 고유 타입 집합이 일치해야 합니다")
+        .containsExactlyInAnyOrderElementsOf(jsonSubTypesClasses);
+  }
+}

--- a/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/RoomControllerTest.java
+++ b/live-chat-server/src/test/java/org/giglab/live/presentation/api/v1/controller/RoomControllerTest.java
@@ -48,8 +48,7 @@ class RoomControllerTest {
   @DisplayName("채팅방 생성 성공 - 201 CREATED")
   void createRoomSuccessReturns201() throws Exception {
     // given
-    CreateRoomRequest request = new CreateRoomRequest();
-    request.setTitle("테스트 방송");
+    CreateRoomRequest request = new CreateRoomRequest("테스트 방송");
 
     CreateRoomResponse response =
         new CreateRoomResponse(
@@ -78,8 +77,7 @@ class RoomControllerTest {
   @DisplayName("채팅방 생성 실패 - 빈 제목 400 BAD_REQUEST")
   void createRoomEmptyTitleReturns400() throws Exception {
     // given
-    CreateRoomRequest request = new CreateRoomRequest();
-    request.setTitle(""); // 빈 문자열
+    CreateRoomRequest request = new CreateRoomRequest(""); // 빈 문자열
 
     // when & then
     mockMvc
@@ -97,8 +95,7 @@ class RoomControllerTest {
   @DisplayName("채팅방 생성 실패 - 50자 초과 제목 400 BAD_REQUEST")
   void createRoomTitleExceeds50CharactersReturns400() throws Exception {
     // given
-    CreateRoomRequest request = new CreateRoomRequest();
-    request.setTitle("A".repeat(51)); // 51자
+    CreateRoomRequest request = new CreateRoomRequest("A".repeat(51)); // 51자
 
     // when & then
     mockMvc
@@ -118,8 +115,7 @@ class RoomControllerTest {
   @DisplayName("채팅방 생성 실패 - null 제목 400 BAD_REQUEST")
   void createRoomNullTitleReturns400() throws Exception {
     // given
-    CreateRoomRequest request = new CreateRoomRequest();
-    request.setTitle(null); // null
+    CreateRoomRequest request = new CreateRoomRequest(null); // null
 
     // when & then
     mockMvc
@@ -136,8 +132,7 @@ class RoomControllerTest {
   @DisplayName("채팅방 생성 실패 - 공백만 있는 제목 400 BAD_REQUEST")
   void createRoomBlankTitleReturns400() throws Exception {
     // given
-    CreateRoomRequest request = new CreateRoomRequest();
-    request.setTitle("   "); // 공백만
+    CreateRoomRequest request = new CreateRoomRequest("   "); // 공백만
 
     // when & then
     mockMvc
@@ -154,8 +149,7 @@ class RoomControllerTest {
   @DisplayName("채팅방 생성 성공 - 정확히 50자 제목 201 CREATED")
   void createRoomTitleExactly50CharactersReturns201() throws Exception {
     // given
-    CreateRoomRequest request = new CreateRoomRequest();
-    request.setTitle("A".repeat(50)); // 정확히 50자
+    CreateRoomRequest request = new CreateRoomRequest("A".repeat(50)); // 정확히 50자
 
     CreateRoomResponse response =
         new CreateRoomResponse("ROOM_123456789ABC", "A".repeat(50), Instant.now(), Instant.now());

--- a/live-commerce-api/Dockerfile
+++ b/live-commerce-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:8.14-jdk21 AS build
+FROM gradle:8.14-jdk25 AS build
 
 WORKDIR /app
 
@@ -20,7 +20,7 @@ RUN gradle :live-commerce-api:bootJar --no-daemon
 
 RUN test -f live-commerce-api/build/libs/*.jar || (echo "JAR file not found" && exit 1)
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 
 RUN addgroup -S live && adduser -S live -G live
 

--- a/live-commerce-api/build.gradle
+++ b/live-commerce-api/build.gradle
@@ -14,7 +14,7 @@ bootJar{
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/live-commerce-api/src/main/resources/application.yml
+++ b/live-commerce-api/src/main/resources/application.yml
@@ -7,6 +7,9 @@ server:
 spring:
   profiles:
     default: local
+  threads:
+    virtual:
+      enabled: true
   servlet:
     encoding:
       charset: UTF-8

--- a/live-commerce-core/build.gradle
+++ b/live-commerce-core/build.gradle
@@ -15,7 +15,7 @@ ext {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
Java 21 → 25(LTS) 업그레이드와 함께 Record, Sealed Interface, Virtual Thread를 실제 코드에 적용합니다. Java 25의 JEP 491(synchronized pinning 해소)을 통해 Virtual Thread가 라이브러리 내부 `synchronized` 블록에서도 안전하게 동작합니다.


### Issue
- closes #108


### Why
- Java 25(LTS)에서 JEP 491로 Virtual Thread의 `synchronized` pinning 문제가 해소되어 안전한 적용이 가능해짐
- `live-chat-server`의 FAQ·채팅 비동기 처리가 `ThreadPoolTaskExecutor` 기반으로 스레드 풀 크기 튜닝 부담이 있었음
- `CreateRoomRequest`, `GetRoomResponse` 등 불변 데이터 운반 클래스가 Lombok 기반 클래스로 작성되어 있어 Record 전환 여지가 있었음
- `ActionResponse`의 허용 구현체가 코드 상 제약 없이 열려 있어 Sealed Interface 적용이 필요했음


### What
- **Java 25 업그레이드**: `build.gradle`(루트, `live-commerce-core`, `live-commerce-api`) 및 두 모듈 Dockerfile 모두 `jdk21` → `jdk25` 변경
- **Virtual Thread 적용**
  - `live-chat-server`: `AsyncConfig` `ThreadPoolTaskExecutor` → `Executors.newVirtualThreadPerTaskExecutor()` 전환, `application.yml` 풀 설정 제거 및 `spring.threads.virtual.enabled: true` 추가
  - `live-commerce-api`: `application.yml`에 `spring.threads.virtual.enabled: true` 추가 (Tomcat 요청 스레드 Virtual Thread 전환)
- **Record 전환** (`live-chat-server`): `CreateRoomRequest`, `GetRoomResponse` Lombok 클래스 → Record
- **Sealed Interface 적용** (`live-chat-server`): `ActionResponse` → `sealed interface permits DefaultActionResponse, JoinRoomResponse, ShowBannerResponse, HideBannerResponse`


### How
- Java 25 툴체인은 모듈별 `build.gradle`이 루트 설정을 오버라이드하므로 루트 + 각 모듈 `build.gradle` 모두 수정
- `ThreadPoolTaskExecutor` 제거로 `MeterRegistry` 의존성 및 `@Value` 풀 크기 설정 전부 제거 — Virtual Thread는 작업마다 스레드를 생성하므로 풀/거부정책 개념 불필요
- `ActionResponse`에 `sealed` + `permits` 추가만으로 기존 `@JsonTypeInfo`/`@JsonSubTypes` Jackson 다형성 구조 유지
- `CreateRoomRequest` Record 전환으로 테스트 코드 `new CreateRoomRequest()` + `setTitle(...)` → `new CreateRoomRequest(title)` 패턴으로 일괄 수정


### Test
- `./gradlew :live-chat-server:compileJava :live-commerce-api:compileJava :live-commerce-core:compileJava` → BUILD SUCCESSFUL 확인
- `./gradlew :live-chat-server:compileTestJava` → BUILD SUCCESSFUL 확인
- Virtual Thread 동작 확인: 기동 후 `Thread.currentThread().isVirtual()` 로그 또는 JFR로 확인 가능
- Dockerfile 이미지 가용성 확인 필요: `docker pull gradle:8.14-jdk25`, `docker pull eclipse-temurin:25-jre-alpine`