### PR TITLE
[#112] fix: 채팅 메시지 미표시 및 FAQ 탭 스크롤 버그 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Query query = new Query(
 
 | 분류 | 기술 |
 |------|------|
-| Language | Java 21 |
+| Language | Java 25 |
 | Framework | Spring Boot 4.0, Spring AI |
 | Real-time | Spring WebSocket, STOMP, Redis Pub/Sub |
 | ORM | Spring Data JPA, QueryDSL, Spring Data MongoDB |
@@ -150,8 +150,11 @@ Query query = new Query(
 ## 실행 방법
 
 ```bash
-# 인프라 (Redis, MySQL, MongoDB, Elasticsearch, Prometheus, Grafana)
+# 인프라 (Redis, MySQL, MongoDB, Elasticsearch)
 docker compose -f docker-compose.infra.yml up -d
+
+# 모니터링 (Prometheus, Grafana, Redis Exporter)
+docker compose -f docker-compose.infra.yml -f docker-compose.monitoring.yml up -d
 
 # 채팅 서버
 docker compose -f docker-compose.infra.yml -f docker-compose.chat.yml up -d
@@ -159,8 +162,11 @@ docker compose -f docker-compose.infra.yml -f docker-compose.chat.yml up -d
 # 커머스 API
 docker compose -f docker-compose.infra.yml -f docker-compose.api.yml up -d
 
+# 이벤트 수집 (Kafka, ClickHouse, Vector)
+docker compose -f docker-compose.infra.yml -f docker-compose.collector.yml up -d
+
 # 전체 스택
-docker compose -f docker-compose.infra.yml -f docker-compose.chat.yml -f docker-compose.api.yml up -d
+docker compose -f docker-compose.infra.yml -f docker-compose.monitoring.yml -f docker-compose.chat.yml -f docker-compose.api.yml up -d
 ```
 
 ### 이미지 빌드

--- a/live-chat-server/src/main/java/org/giglab/live/presentation/subscriber/RoomBroadcastSubscriber.java
+++ b/live-chat-server/src/main/java/org/giglab/live/presentation/subscriber/RoomBroadcastSubscriber.java
@@ -45,7 +45,7 @@ public class RoomBroadcastSubscriber implements MessageListener {
         recoverIfGap(roomId, seq);
       }
 
-      messagingTemplate.convertAndSend(StompDestination.ROOM_PREFIX + roomId, payload);
+      messagingTemplate.convertAndSend(StompDestination.ROOM_PREFIX + roomId, body);
       log.debug("STOMP broadcast - roomId={}, seq={}", roomId, seq);
     } catch (Exception e) {
       log.error("Redis 수신 메시지 처리 실패 - channel={}", channel, e);

--- a/web-client/pages/broadcasts/[id].tsx
+++ b/web-client/pages/broadcasts/[id].tsx
@@ -135,6 +135,7 @@ function ChatQnAPanel({
   const faqBottomRef = useRef<HTMLDivElement>(null);
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const faqContainerRef = useRef<HTMLDivElement>(null);
+  const prevTabRef = useRef<string>(tab);
   const isAtChatBottomRef = useRef(true);
   const [faqInput, setFaqInput] = useState('');
 
@@ -160,11 +161,14 @@ function ChatQnAPanel({
   }, [messages, tab]);
 
   useEffect(() => {
-    if (tab === 'faq') {
+    const tabChanged = prevTabRef.current !== tab;
+    prevTabRef.current = tab;
+    // 탭 전환 시에는 스크롤하지 않고, faqMessages 변경 시에만 스크롤
+    if (tab === 'faq' && !tabChanged) {
       const el = faqContainerRef.current;
       if (el) el.scrollTop = el.scrollHeight;
     }
-  }, [faqMessages]);
+  }, [faqMessages, tab]);
 
   const handleChatScroll = useCallback(() => {
     const el = chatContainerRef.current;

--- a/web-client/pages/broadcasts/[id].tsx
+++ b/web-client/pages/broadcasts/[id].tsx
@@ -137,6 +137,7 @@ function ChatQnAPanel({
   const faqContainerRef = useRef<HTMLDivElement>(null);
   const prevTabRef = useRef<string>(tab);
   const isAtChatBottomRef = useRef(true);
+  const isAtFaqBottomRef = useRef(true);
   const [faqInput, setFaqInput] = useState('');
 
   const chatMessages = useMemo(
@@ -163,17 +164,23 @@ function ChatQnAPanel({
   useEffect(() => {
     const tabChanged = prevTabRef.current !== tab;
     prevTabRef.current = tab;
-    // 탭 전환 시에는 스크롤하지 않고, faqMessages 변경 시에만 스크롤
-    if (tab === 'faq' && !tabChanged) {
+    // 탭 전환 시에는 스크롤하지 않고, FAQ 메시지 수 증가 시에만 스크롤
+    if (tab === 'faq' && !tabChanged && isAtFaqBottomRef.current) {
       const el = faqContainerRef.current;
       if (el) el.scrollTop = el.scrollHeight;
     }
-  }, [faqMessages, tab]);
+  }, [faqMessages.length, tab]);
 
   const handleChatScroll = useCallback(() => {
     const el = chatContainerRef.current;
     if (!el) return;
     isAtChatBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  }, []);
+
+  const handleFaqScroll = useCallback(() => {
+    const el = faqContainerRef.current;
+    if (!el) return;
+    isAtFaqBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
   }, []);
 
   const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -329,7 +336,7 @@ function ChatQnAPanel({
       ) : (
         /* 라이브: 실시간 AI FAQ 탭 */
         <>
-          <div className="lp-faq-body" ref={faqContainerRef}>
+          <div className="lp-faq-body" ref={faqContainerRef} onScroll={handleFaqScroll}>
             {faqMessages.length === 0 ? (
               <div className="lp-faq-info">AI에게 상품 관련 질문을 해보세요. 답변이 채팅방 전체에 공유됩니다.</div>
             ) : (

--- a/web-client/pages/broadcasts/[id].tsx
+++ b/web-client/pages/broadcasts/[id].tsx
@@ -134,6 +134,7 @@ function ChatQnAPanel({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const faqBottomRef = useRef<HTMLDivElement>(null);
   const chatContainerRef = useRef<HTMLDivElement>(null);
+  const faqContainerRef = useRef<HTMLDivElement>(null);
   const isAtChatBottomRef = useRef(true);
   const [faqInput, setFaqInput] = useState('');
 
@@ -159,8 +160,11 @@ function ChatQnAPanel({
   }, [messages, tab]);
 
   useEffect(() => {
-    if (tab === 'faq') faqBottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [faqMessages, tab]);
+    if (tab === 'faq') {
+      const el = faqContainerRef.current;
+      if (el) el.scrollTop = el.scrollHeight;
+    }
+  }, [faqMessages]);
 
   const handleChatScroll = useCallback(() => {
     const el = chatContainerRef.current;
@@ -321,7 +325,7 @@ function ChatQnAPanel({
       ) : (
         /* 라이브: 실시간 AI FAQ 탭 */
         <>
-          <div className="lp-faq-body">
+          <div className="lp-faq-body" ref={faqContainerRef}>
             {faqMessages.length === 0 ? (
               <div className="lp-faq-info">AI에게 상품 관련 질문을 해보세요. 답변이 채팅방 전체에 공유됩니다.</div>
             ) : (


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
채팅 메시지가 화면에 표시되지 않는 버그와 FAQ 탭 클릭 시 전체 페이지가 스크롤되는 버그를 수정합니다. README의 Java 버전 및 실행 방법도 최신화합니다.


### Issue
- closes #112


### Why
- `RoomBroadcastSubscriber`에서 `JsonNode` 객체를 `SimpMessagingTemplate.convertAndSend`로 전달 시 Spring 메시지 컨버터가 `JsonNode`의 JSON 콘텐츠 대신 Java 객체의 getter 결과값을 직렬화하여 채팅 메시지가 정상적으로 전달되지 않음
- FAQ 탭 클릭 시 `scrollIntoView`로 인해 메시지 컨테이너가 아닌 전체 페이지가 스크롤되는 UX 문제


### What
- `RoomBroadcastSubscriber`: `convertAndSend` 인자를 `payload`(JsonNode) → `body`(원본 JSON 문자열)로 변경
- `ChatQnAPanel`: FAQ 스크롤을 `scrollIntoView` → `faqContainerRef.scrollTop = scrollHeight` 방식으로 변경, 탭 전환 시 자동 스크롤 제거
- `README.md`: Java 버전 21 → 25 업데이트, docker-compose 실행 방법 최신화 (monitoring/collector 분리 반영)


### How
- Redis에서 수신한 메시지는 이미 올바른 JSON 문자열이므로 `JsonNode`로 파싱 후 재직렬화할 필요 없이 `body`를 그대로 전달
- FAQ 컨테이너에 `faqContainerRef` 추가 후 채팅 탭과 동일한 방식(`scrollTop = scrollHeight`)으로 컨테이너 내부만 스크롤되도록 통일
- useEffect dependency에서 `tab` 제거하여 탭 전환 시 불필요한 스크롤 방지


### Test
- 방송 시작 후 채팅 메시지 전송 → STOMP 수신 메시지 body에 정상 JSON 확인
- FAQ 탭 클릭 시 페이지 스크롤 없음 확인
- 새 FAQ 메시지 수신 시 FAQ 컨테이너 내부만 스크롤 확인