### PR TITLE
[#114] chore: Harness Engineering 적용 — 전 모듈 CLAUDE.md 작성 및 컴파일 훅 설정

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file=$(echo \"$CLAUDE_TOOL_INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('file_path',''))\" 2>/dev/null); if echo \"$file\" | grep -qE '\\.java$'; then cd /Users/jake/Documents/workspace/projectspace/live-platform-lab && module=$(echo \"$file\" | grep -oE 'live-[a-z-]+' | head -1); if [ -n \"$module\" ]; then echo \"[compile] $module\"; ./gradlew :${module}:compileJava -q 2>&1 | tail -20; fi; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,3 @@ docs/claude
 uploads
 # Claude Code
 .claude/settings.local.json
-.claude/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ db_dev.trace.db
 .DS_Store
 docs/claude
 uploads
+# Claude Code
+.claude/settings.local.json
+.claude/settings.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# Live Platform Lab — Claude Code 가이드
+
+## 프로젝트 개요
+
+AI 기반 라이브 커머스 플랫폼. 실시간 채팅·RAG Q&A·LLM 인사이트를 직접 설계·구현한 포트폴리오 프로젝트.
+
+## 모듈 구조
+
+```
+live-platform-lab/
+├── live-commerce-core/   # 핵심 도메인 (Hexagonal Architecture)
+├── live-commerce-api/    # REST API 서버 (포트 8090)
+├── live-chat-server/     # WebSocket/STOMP 채팅 서버 (포트 8080)
+└── web-client/           # Next.js 14 프론트엔드 (포트 3000)
+```
+
+각 모듈의 상세 내용은 해당 디렉토리의 CLAUDE.md를 참고할 것.
+
+## 기술 스택
+
+- **Language**: Java 25, TypeScript
+- **Framework**: Spring Boot 4.0, Next.js 14
+- **Infra**: MySQL 8, MongoDB 7, Redis 7, Elasticsearch 9
+- **Real-time**: STOMP over SockJS, Redis Pub/Sub
+- **AI**: OpenAI GPT-4o-mini, Spring AI, RAG
+
+## 개발 워크플로우
+
+### 브랜치 전략
+
+```
+main          ← 프로덕션
+develop       ← 통합 브랜치
+feature/#{이슈번호}   ← 기능 개발
+```
+
+### 커밋 컨벤션
+
+```
+[#{이슈번호}] type: 설명
+
+type: feat | fix | refactor | docs | chore | perf
+```
+
+### PR 흐름
+
+1. `feature/#{N}` 브랜치 생성
+2. 개발 후 `/pr-create` 로 PR 생성 (base: develop)
+3. `/pr-review` 로 리뷰 → `/pr-apply` 로 반영
+
+## Available Skills
+
+| 명령어 | 용도 |
+|--------|------|
+| `/plan` | 이슈 분석 → 구현 계획 문서 생성 |
+| `/issue-create` | 변경사항 분석 → GitHub 이슈 생성 |
+| `/pr-create` | 현재 브랜치 커밋 분석 → PR 생성 |
+| `/pr-review` | PR 코드 리뷰 → 코멘트 등록 |
+| `/pr-apply` | PR 리뷰 코멘트 → 코드 반영 |
+| `/question` | 질문 답변 → docs/claude/question/ 저장 |
+
+## 빌드 & 실행
+
+```bash
+# 전체 빌드
+./gradlew build
+
+# 모듈별 컴파일
+./gradlew :live-chat-server:compileJava
+./gradlew :live-commerce-core:compileJava
+./gradlew :live-commerce-api:compileJava
+
+# 인프라
+make infra-up          # Redis, MySQL, MongoDB, Elasticsearch
+docker compose -f docker-compose.monitoring.yml up -d  # Prometheus, Grafana
+
+# 코드 포맷 (Spotless)
+./gradlew spotlessApply
+```
+
+## 코드 품질 규칙
+
+- **포맷터**: Spotless (Google Java Format) — PR 전 반드시 실행
+- **패키지**: `org.giglab.live.*`
+- **예외**: 도메인 예외는 `*DomainException`, 에러코드는 `*ErrorCode` enum
+- **트랜잭션**: 외부 HTTP 호출은 트랜잭션 밖에서 수행
+
+## 알려진 패턴 & 주의사항
+
+### Redis Pub/Sub → STOMP 브로드캐스트
+`RoomBroadcastPublisher`가 Redis에 JSON 문자열을 발행하면,
+`RoomBroadcastSubscriber`가 수신해 STOMP로 전달한다.
+**주의**: `SimpMessagingTemplate.convertAndSend`에 `JsonNode` 객체를 넘기면
+JSON 콘텐츠가 아닌 클래스 getter 결과가 직렬화된다 → 반드시 `body`(문자열)를 전달.
+
+### ActionResponse 다형성
+`@JsonTypeInfo(property = "action", visible = true)` + `@JsonSubTypes`로
+`DefaultActionResponse` 하나가 여러 action 이름에 매핑된다.
+직렬화 시 실제 `action` 필드값이 사용되므로 정상 동작함.
+
+### chatRoomId 생명주기
+캠페인 시작 시 채팅방 생성이 선행 조건 (PR #110).
+`campaign.chatRoomId`가 null이면 WebSocket 연결 불가.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,12 @@ live-platform-lab/
 ### 브랜치 전략
 
 ```
-main          ← 프로덕션
-develop       ← 통합 브랜치
-feature/#{이슈번호}   ← 기능 개발
+main                 ← 프로덕션
+develop              ← 통합 브랜치
+feature/#{이슈번호}  ← 기능 개발
+fix/#{이슈번호}      ← 버그 수정
+refactor/#{이슈번호} ← 리팩토링
+chore/#{이슈번호}    ← 설정·문서·도구
 ```
 
 ### 커밋 컨벤션

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,12 @@ AI 기반 라이브 커머스 플랫폼. 실시간 채팅·RAG Q&A·LLM 인사�
 
 ```
 live-platform-lab/
-├── live-commerce-core/   # 핵심 도메인 (Hexagonal Architecture)
-├── live-commerce-api/    # REST API 서버 (포트 8090)
-├── live-chat-server/     # WebSocket/STOMP 채팅 서버 (포트 8080)
-└── web-client/           # Next.js 14 프론트엔드 (포트 3000)
+├── live-commerce-core/    # 핵심 도메인 (Hexagonal Architecture)
+├── live-commerce-api/     # REST API 서버 (포트 8090)
+├── live-chat-server/      # WebSocket/STOMP 채팅 서버 (포트 8080)
+├── live-event-collector/  # 이벤트 수집 → Kafka 발행 (포트 8070)
+├── live-analytics-api/    # ClickHouse 기반 분석 API (포트 8060)
+└── web-client/            # Next.js 14 프론트엔드 (포트 3000)
 ```
 
 각 모듈의 상세 내용은 해당 디렉토리의 CLAUDE.md를 참고할 것.
@@ -69,6 +71,8 @@ type: feat | fix | refactor | docs | chore | perf
 ./gradlew :live-chat-server:compileJava
 ./gradlew :live-commerce-core:compileJava
 ./gradlew :live-commerce-api:compileJava
+./gradlew :live-event-collector:compileJava
+./gradlew :live-analytics-api:compileJava
 
 # 인프라
 make infra-up          # Redis, MySQL, MongoDB, Elasticsearch

--- a/live-analytics-api/CLAUDE.md
+++ b/live-analytics-api/CLAUDE.md
@@ -1,0 +1,49 @@
+# live-analytics-api — Claude Code 가이드
+
+## 역할
+
+라이브 커머스 이벤트 분석 API. ClickHouse OLAP DB 기반으로 퍼널·UTM·시청자 지표 조회.
+
+- **포트**: 8060
+- **패키지**: `org.giglab.live.analytics.api`
+
+## 패키지 구조
+
+```
+src/main/java/org/giglab/live/analytics/api/
+├── presentation/
+│   ├── controller/        # AnalyticsController
+│   └── dto/               # FunnelResponse, UtmResponse, ViewerResponse
+├── application/
+│   ├── AnalyticsService
+│   ├── usecase/           # GetFunnelUseCase, GetUtmUseCase, GetViewerUseCase
+│   ├── dto/               # GetFunnelResult, GetUtmResult, GetViewerResult, DateRange
+│   └── port/persistence/  # AnalyticsQueryPort (인터페이스)
+└── infrastructure/
+    ├── adapter/           # ClickHouseAnalyticsQueryAdapter
+    └── clickhouse/        # FunnelClickHouseRepository, UtmClickHouseRepository, ViewerClickHouseRepository
+```
+
+## 아키텍처
+
+Hexagonal Architecture. ClickHouse 쿼리는 `AnalyticsQueryPort` 인터페이스를 통해서만 접근.
+
+```
+AnalyticsController
+  → AnalyticsService (UseCase 조합)
+    → AnalyticsQueryPort (포트)
+      → ClickHouseAnalyticsQueryAdapter (어댑터)
+        → ClickHouse JDBC
+```
+
+## 데이터 소스
+
+- **ClickHouse**: OLAP 이벤트 데이터 (live-event-collector가 Kafka → Vector → ClickHouse로 적재)
+- `live-event-collector`가 수집한 이벤트를 집계해 분석
+
+## 빌드
+
+```bash
+./gradlew :live-analytics-api:compileJava
+./gradlew :live-analytics-api:test
+```

--- a/live-chat-server/CLAUDE.md
+++ b/live-chat-server/CLAUDE.md
@@ -1,0 +1,93 @@
+# live-chat-server — Claude Code 가이드
+
+## 역할
+
+WebSocket/STOMP 기반 실시간 채팅 서버. Redis Pub/Sub으로 멀티 인스턴스 확장.
+
+- **포트**: 8080
+- **패키지**: `org.giglab.live`
+
+## 패키지 구조
+
+```
+src/main/java/org/giglab/live/
+├── application/
+│   ├── command/              # ActionDispatcher + ActionHandler 구현체
+│   │   ├── chat/             # SendMessage, JoinRoom, LeaveRoom, FaqQuestion
+│   │   └── banner/           # ProductBannerOn, ProductBannerOff
+│   ├── dto/
+│   │   ├── action/           # ActionRequest, ActionResponse, DefaultActionResponse...
+│   │   └── ChatMessageResponse.java
+│   ├── service/              # ChatMessageService, FaqAnswerService, ViewerSessionService
+│   └── port/                 # 포트 인터페이스 (persistence, messaging, ai)
+├── domain/
+│   └── model/                # ChatMessage, Room (도메인 엔티티)
+├── infrastructure/
+│   ├── adapter/              # RoomBroadcastPublisher, HttpChatRoomAdapter
+│   ├── redis/                # RedisRoomRepository, RedisPubSubChannel
+│   ├── mongodb/              # ChatMessageRepository
+│   └── ai/                   # FaqAnswerAdapter (OpenAI 연동)
+└── presentation/
+    ├── api/v1/controller/
+    │   ├── websocket/        # RoomActionController (@MessageMapping)
+    │   └── RoomController, ChatMessageController (REST)
+    └── subscriber/           # RoomBroadcastSubscriber (Redis → STOMP)
+```
+
+## 메시지 흐름
+
+```
+클라이언트 SEND /send/room.action
+  → RoomActionController.handle(ActionRequest)
+  → ActionDispatcher.dispatch() → ActionHandler.execute()
+  → RoomActionFacade: assignSeq → publish → saveIfNeeded
+  → RoomBroadcastPublisher → Redis channel "room:{roomId}"
+  → RoomBroadcastSubscriber.onMessage()
+  → SimpMessagingTemplate → /sub/room/{roomId}
+  → 클라이언트 수신
+```
+
+## Action 타입
+
+`ActionType` enum에 정의. key 값이 실제 전송되는 문자열.
+
+| ActionType | key | 저장 여부 |
+|-----------|-----|----------|
+| CHAT_MESSAGE | CHAT.MESSAGE | ✅ MongoDB |
+| FAQ_QUESTION | FAQ.QUESTION | ✅ MongoDB |
+| FAQ_ANSWER | FAQ.ANSWER | ✅ MongoDB |
+| FAQ_ERROR | FAQ.ERROR | ✅ MongoDB |
+| CHAT_JOIN | CHAT.JOIN | ❌ |
+| CHAT_LEAVE | CHAT.LEAVE | ❌ |
+| VIEWER_COUNT | VIEWER.COUNT | ❌ |
+| PRODUCT_BANNER_ON | PRODUCT.BANNER.ON | ❌ |
+| PRODUCT_BANNER_OFF | PRODUCT.BANNER.OFF | ❌ |
+
+## 핵심 클래스
+
+- `ActionDispatcher`: action 문자열 → `ActionHandler` O(1) 매핑
+- `DefaultActionResponse`: 대부분의 메시지에 사용하는 응답 DTO (sealed interface 구현체)
+- `ChatMessageService.assignSeq()`: Redis INCR으로 seq 부여 (메시지 유실 감지용)
+- `RoomBroadcastSubscriber.recoverIfGap()`: seq gap 감지 시 MongoDB에서 복구 메시지 재전송
+
+## WebSocket 설정
+
+- STOMP endpoint: `/ws` (SockJS fallback 포함)
+- Subscribe prefix: `/sub`
+- Send prefix: `/send`
+- Heartbeat: 5초
+
+## 빌드 & 테스트
+
+```bash
+./gradlew :live-chat-server:compileJava
+./gradlew :live-chat-server:test
+./gradlew :live-chat-server:test --tests "org.giglab.live.application.command.chat.*"
+```
+
+## 주의사항
+
+- `RoomBroadcastSubscriber`에서 `convertAndSend`는 반드시 `body`(JSON 문자열) 사용
+  (`JsonNode` 객체를 넘기면 getter 직렬화 버그 발생)
+- `saveIfNeeded`는 `@Async`로 비동기 처리 — 트랜잭션 없음
+- seq가 0인 메시지는 MongoDB에 저장하지 않음 (guard 존재)

--- a/live-commerce-api/CLAUDE.md
+++ b/live-commerce-api/CLAUDE.md
@@ -1,0 +1,72 @@
+# live-commerce-api — Claude Code 가이드
+
+## 역할
+
+상품·카테고리·캠페인 REST API 서버. `live-commerce-core` 도메인을 조합해 클라이언트에 노출.
+
+- **포트**: 8090
+- **패키지**: `org.giglab.live.commerce.api`
+- **Swagger**: http://localhost:8090/swagger-ui.html
+
+## 패키지 구조
+
+```
+src/main/java/org/giglab/live/commerce/api/
+├── controller/
+│   ├── ProductController     # 상품 CRUD, PDF 임베딩, FAQ 생성, Q&A
+│   ├── CategoryController    # 카테고리 트리
+│   └── CampaignController    # 방송 캠페인 관리, 방송 시작/종료
+├── dto/
+│   ├── product/              # ProductRequest, ProductResponse
+│   ├── category/             # CategoryRequest, CategoryResponse
+│   ├── campaign/             # CampaignRequest, CampaignResponse, BroadcastStatusResponse
+│   └── pagination/           # CursorPagination, OffsetPagination
+├── mapper/                   # MapStruct 매퍼 (Result ↔ Response 변환)
+│   ├── ProductMapper
+│   ├── CategoryMapper
+│   ├── CampaignMapper
+│   └── CampaignReportMapper
+├── facade/                   # UseCase 조합 파사드
+└── config/
+```
+
+## DTO 변환 규칙
+
+**core Result DTO → api Response DTO** 변환은 반드시 MapStruct 매퍼 사용.
+
+```java
+// 올바른 패턴
+GetCampaignResult result = campaignService.getCampaign(id);
+return ApiResponse.success(campaignMapper.toResponse(result));
+```
+
+엔티티를 직접 컨트롤러에 노출하지 않는다.
+
+## 응답 형식
+
+```java
+public class ApiResponse<T> {
+  private final T data;
+  private final ErrorResponse error;
+}
+```
+
+성공: `{ "data": ..., "error": null }`
+실패: `{ "data": null, "error": { "code": "...", "message": "..." } }`
+
+## 주요 API 엔드포인트
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | /campaigns/{id} | 캠페인 상세 (chatRoomId 포함) |
+| POST | /campaigns/{id}/start | 방송 시작 → 채팅방 생성 후 ON_AIR |
+| POST | /campaigns/{id}/end | 방송 종료 → ENDED |
+| POST | /campaigns/{id}/reports | AI 리포트 조회/생성 |
+| GET | /products/{id}/faq-samples | 사전 Q&A 목록 |
+
+## 빌드
+
+```bash
+./gradlew :live-commerce-api:compileJava
+./gradlew :live-commerce-api:test
+```

--- a/live-commerce-api/CLAUDE.md
+++ b/live-commerce-api/CLAUDE.md
@@ -6,7 +6,7 @@
 
 - **포트**: 8090
 - **패키지**: `org.giglab.live.commerce.api`
-- **Swagger**: http://localhost:8090/swagger-ui.html
+- **Swagger**: http://localhost:8090/swagger-ui
 
 ## 패키지 구조
 

--- a/live-commerce-core/CLAUDE.md
+++ b/live-commerce-core/CLAUDE.md
@@ -1,0 +1,79 @@
+# live-commerce-core — Claude Code 가이드
+
+## 역할
+
+상품·캠페인 핵심 도메인. Hexagonal Architecture (Ports & Adapters) 적용.
+`live-commerce-api`가 이 모듈을 의존한다.
+
+- **패키지**: `org.giglab.live.commerce.core`
+
+## 패키지 구조
+
+```
+src/main/java/org/giglab/live/commerce/core/
+├── campaign/
+│   ├── application/
+│   │   ├── CampaignService.java          # 퍼사드 (UseCase 조합)
+│   │   ├── dto/                          # Result DTO (GetCampaignResult 등)
+│   │   ├── port/
+│   │   │   ├── persistence/              # CampaignStorePort, CampaignQueryPort
+│   │   │   └── external/                 # ChatRoomCreatePort, ChatRoomDeletePort
+│   │   └── usecase/                      # 단일 책임 UseCase (각각 @Transactional)
+│   │       ├── StartCampaignUseCase      # 방송 시작 + chatRoomId 저장
+│   │       ├── EndCampaignUseCase
+│   │       └── ...
+│   └── domain/
+│       ├── entity/
+│       │   ├── Campaign.java             # JPA 엔티티 (chatRoomId 포함)
+│       │   └── types/BroadcastStatusType # SCHEDULED | ON_AIR | ENDED
+│       └── exception/
+│           ├── CampaignDomainException
+│           └── CampaignErrorCode         # enum
+└── product/
+    ├── application/                      # 상품·PDF·FAQ 유사 구조
+    └── domain/
+```
+
+## 도메인 규칙
+
+### Campaign 생명주기
+
+```
+SCHEDULED → ON_AIR → ENDED
+```
+
+- `campaign.start()`: 상태를 ON_AIR로 변경
+- `campaign.assignChatRoom(roomId)`: chatRoomId 저장
+- `campaign.end()`: 상태를 ENDED로 변경, chatRoomId null 처리
+
+### 트랜잭션 분리 원칙
+
+외부 HTTP 호출(`ChatRoomCreatePort`)은 트랜잭션 밖에서 먼저 수행 후,
+성공하면 DB 트랜잭션 시작.
+
+```java
+// CampaignService.start()
+String roomId = chatRoomCreatePort.createRoom(title); // 트랜잭션 밖
+return startCampaignUseCase.execute(campaignId, roomId); // @Transactional
+```
+
+## UseCase 작성 규칙
+
+- 클래스 하나 = 책임 하나
+- `@Service @Transactional`
+- `CampaignStorePort.findEntityById()`로 엔티티 조회 후 도메인 메서드 호출
+- 결과는 Result DTO로 반환 (엔티티 직접 노출 금지)
+
+## 예외 처리
+
+```java
+throw new CampaignDomainException(CampaignErrorCode.NOT_FOUND, "메시지");
+throw new CampaignDomainException(CampaignErrorCode.CHAT_ROOM_CREATE_FAILED, cause);
+```
+
+## 빌드
+
+```bash
+./gradlew :live-commerce-core:compileJava
+./gradlew :live-commerce-core:test
+```

--- a/live-commerce-core/CLAUDE.md
+++ b/live-commerce-core/CLAUDE.md
@@ -44,7 +44,8 @@ SCHEDULED → ON_AIR → ENDED
 
 - `campaign.start()`: 상태를 ON_AIR로 변경
 - `campaign.assignChatRoom(roomId)`: chatRoomId 저장
-- `campaign.end()`: 상태를 ENDED로 변경, chatRoomId null 처리
+- `campaign.end()`: 상태를 ENDED로 변경, endedAt 설정
+- `campaign.clearChatRoom()`: chatRoomId를 null로 초기화 (`EndCampaignUseCase`는 현재 호출하지 않음)
 
 ### 트랜잭션 분리 원칙
 

--- a/live-event-collector/CLAUDE.md
+++ b/live-event-collector/CLAUDE.md
@@ -1,0 +1,64 @@
+# live-event-collector — Claude Code 가이드
+
+## 역할
+
+사용자 이벤트를 HTTP로 수집해 Kafka에 발행. Vector가 Kafka → ClickHouse로 적재.
+
+- **포트**: 8070
+- **패키지**: `org.giglab.live.collector`
+
+## 패키지 구조
+
+```
+src/main/java/org/giglab/live/collector/
+├── presentation/
+│   ├── controller/        # EventController (POST /api/v1/events)
+│   └── dto/               # EventRequest
+├── application/
+│   ├── EventService
+│   ├── usecase/           # SendEventUseCase
+│   └── port/              # EventPublisher (인터페이스)
+├── domain/
+│   └── model/
+│       ├── Event
+│       └── types/EventType  # 이벤트 타입 enum
+└── infrastructure/
+    ├── adapter/           # KafkaEventPublisher
+    └── kafka/
+        ├── config/        # KafkaConfig
+        └── EventKafkaPublisher
+```
+
+## 이벤트 흐름
+
+```
+클라이언트 → POST /api/v1/events (EventRequest)
+  → EventService → SendEventUseCase
+  → KafkaEventPublisher → Kafka topic "live-events"
+  → Vector (Kafka consumer) → ClickHouse
+  → live-analytics-api에서 집계 조회
+```
+
+## Kafka 설정
+
+환경 변수 `KAFKA_BOOTSTRAP_SERVERS`로 브로커 주소 주입.
+토픽: `live-events` (파티션 3, 복제 1)
+
+```bash
+# 토픽 생성 (최초 1회)
+make kafka-init
+```
+
+## 인프라 실행
+
+```bash
+make collector-up   # Kafka + Kafka UI + ClickHouse + Vector
+make collector-down
+```
+
+## 빌드
+
+```bash
+./gradlew :live-event-collector:compileJava
+./gradlew :live-event-collector:test
+```

--- a/web-client/CLAUDE.md
+++ b/web-client/CLAUDE.md
@@ -1,0 +1,103 @@
+# web-client — Claude Code 가이드
+
+## 역할
+
+Next.js 14 (Pages Router) 기반 프론트엔드. 방송 관리·실시간 채팅·상품 관리 UI 제공.
+
+- **포트**: 3000
+- **런타임**: Node.js, TypeScript
+
+## 페이지 구조
+
+```
+pages/
+├── broadcasts/
+│   ├── index.tsx          # 방송 목록
+│   └── [id].tsx           # 방송 상세 (채팅·FAQ·AI리포트) ← 핵심 파일
+├── products/
+│   ├── index.tsx          # 상품 목록
+│   └── [id].tsx           # 상품 상세
+└── chat.tsx               # 채팅 데모 (다중 유저 시뮬레이션)
+```
+
+## API 연결
+
+```typescript
+// broadcasts/[id].tsx 상단
+const API_BASE   = process.env.NEXT_PUBLIC_API_URL    ?? 'http://localhost:8090/api/v1'  // 커머스 API
+const CHAT_API_BASE = process.env.NEXT_PUBLIC_CHAT_URL ?? 'http://localhost:8080/api/v1' // 채팅 REST
+const WS_BASE_URL   = process.env.NEXT_PUBLIC_WS_URL  ?? 'http://localhost:8080'         // STOMP
+```
+
+## WebSocket (STOMP) 패턴 — broadcasts/[id].tsx
+
+SockJS + STOMP.js를 CDN으로 동적 로드 (Next.js Script 태그).
+
+### 연결 흐름
+
+```
+areScriptsReady && campaign.chatRoomId && status=live
+  → connect(roomId)
+  → client.subscribe('/sub/room/{roomId}', msg => appendMessage(msg.body))
+  → publishJoin()
+  → loadHistory()  ← REST API로 이전 메시지 조회
+```
+
+### 메시지 타입 → UI 탭 매핑
+
+| action | msgType | 표시 탭 |
+|--------|---------|---------|
+| CHAT.MESSAGE | 'chat' | 💬 채팅 |
+| FAQ.QUESTION | 'faq-question' | 🤖 FAQ |
+| FAQ.ANSWER | 'faq-answer' | 🤖 FAQ |
+| FAQ.ERROR | 'faq-error' | 🤖 FAQ |
+| VIEWER.COUNT | — | 시청자 수 (상태만) |
+| PRODUCT.BANNER.ON/OFF | — | 배너 표시 (상태만) |
+| CHAT.JOIN | — | 무시 (activeBanner 체크만) |
+
+### 중요 refs
+
+| ref | 용도 |
+|-----|------|
+| `clientRef` | STOMP client 인스턴스 |
+| `subRef` | STOMP subscription |
+| `seenKeysRef` | 메시지 중복 제거 (rawBody 기준, max 200) |
+| `isConnectingRef` | 연결 중 플래그 (이중 연결 방지) |
+| `historyLoadedRoomsRef` | 히스토리 로드 완료 roomId 추적 |
+| `isAtChatBottomRef` | 채팅 컨테이너 바닥 여부 |
+| `isAtFaqBottomRef` | FAQ 컨테이너 바닥 여부 |
+
+## ChatQnAPanel 컴포넌트
+
+`messages` 전체를 받아 내부에서 useMemo로 필터링.
+
+```typescript
+const chatMessages = useMemo(
+  () => messages.filter((m) => !m.msgType || m.msgType === 'chat'),
+  [messages]
+);
+const faqMessages = useMemo(
+  () => messages.filter((m) => ['faq-question','faq-answer','faq-error'].includes(m.msgType!)),
+  [messages]
+);
+```
+
+### 스크롤 정책
+
+- 채팅/FAQ 모두 `isAtBottom` ref로 바닥 여부 체크 후 자동 스크롤
+- 탭 전환 시에는 자동 스크롤 없음 (`prevTabRef`로 탭 변경 감지)
+- useEffect dependency: `faqMessages.length` (배열 참조 변경이 아닌 실제 증가 시만)
+
+## 주의사항
+
+- `sendMessage`는 STOMP 전송 성공 시 로컬 상태에 추가하지 않음 (서버 echo 수신 후 추가됨)
+- `loadHistory`는 REST API 응답의 `json.data` 배열을 사용 (`json.data ?? []`)
+- 히스토리 메시지 id는 MongoDB ObjectId (string), 실시간 메시지 id는 `Date.now() + Math.random()`
+
+## 실행
+
+```bash
+cd web-client
+npm install
+npm run dev
+```


### PR DESCRIPTION
<!--
Copilot Review Instruction (Korean):
- 이 PR을 한국어로 리뷰해 주세요.
- 다음을 중점적으로 봐주세요:
  1. 트랜잭션/정합성 이슈
  2. 성능 영향 (DB, 메시지, 배치)
  3. 장애/롤백 리스크
  4. 운영 관점(로그, 모니터링, 알람)
-->

# Summary
Harness Engineering 원칙(Guides + Sensors)에 따라 Claude Code AI 협업 인프라를 프로젝트 전반에 구축. 모든 모듈에 CLAUDE.md를 작성하고, Java 파일 저장 시 자동 컴파일 피드백 훅을 설정.


### Issue
- closes #114


### Why
- AI 코딩 에이전트는 "Model + Harness"로 구성되며, 모델보다 Harness 품질이 출력 신뢰성을 결정
- 모듈별 아키텍처·패턴·주의사항이 문서화되지 않아 세션마다 동일한 컨텍스트를 반복 설명해야 했음
- 컴파일 오류 피드백이 없어 AI가 수정 후 즉각적인 검증이 불가능했음


### What
- 루트 `CLAUDE.md`: 프로젝트 개요, 모듈 구조, 브랜치 전략, 코드 품질 규칙, 알려진 패턴(JsonNode 직렬화 버그, chatRoomId 생명주기 등)
- `live-chat-server/CLAUDE.md`: 메시지 흐름, Action 타입 테이블, 핵심 클래스, Redis Pub/Sub → STOMP 패턴
- `live-commerce-core/CLAUDE.md`: Hexagonal 패키지 구조, UseCase 규칙, 트랜잭션 외부 HTTP 호출 분리 규칙
- `live-commerce-api/CLAUDE.md`: DTO 변환 규칙(MapStruct), 응답 형식, 주요 엔드포인트 표
- `live-analytics-api/CLAUDE.md`: ClickHouse OLAP, Hexagonal 아키텍처
- `live-event-collector/CLAUDE.md`: Kafka 이벤트 파이프라인, 토픽 설정
- `web-client/CLAUDE.md`: STOMP 연결 흐름, 메시지 타입-탭 매핑, refs 표, 스크롤 정책
- `.claude/settings.json` PostToolUse 훅: Java 파일 Edit/Write 후 해당 모듈 자동 `compileJava`
- `.gitignore`: `.claude/settings.local.json` 추가 (개인 권한 설정 git 제외)


### How
- **Guides**: 각 모듈 CLAUDE.md는 역할·패키지 구조·패턴·빌드 명령만 포함, 50–120줄 범위 유지 (Vitthalmirji 권고)
- **Sensor**: PostToolUse 훅이 `$CLAUDE_TOOL_INPUT`에서 파일 경로를 추출해 모듈명을 파싱, `./gradlew :${module}:compileJava` 자동 실행
- 알려진 버그(JsonNode 직렬화, ActionResponse 다형성 등)를 CLAUDE.md "주의사항" 섹션에 명시해 반복 실수 방지


### Test
- Java 파일 수정 시 터미널에 `[compile] {module}` 출력 및 컴파일 결과 자동 표시 확인
- settings.local.json이 `git status`에서 untracked로 나타나지 않음 확인